### PR TITLE
For <item> In <array or string> Do

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -2708,7 +2708,6 @@ begin
   Result := TLapeTree_For.Create(Self, getPDocPos());
 
   try
-
     if (lcoLooseSyntax in FOptions) and isNext([tk_kw_Var]) then
       with ParseVarBlock(True, [tk_kw_To, tk_kw_DownTo]) do
       try
@@ -2731,12 +2730,16 @@ begin
       end
     else
     begin
-      Result.Counter := ParseExpression();
-      Expect([tk_kw_To, tk_kw_DownTo], False, True);
+      Result.Counter := ParseExpression([tk_op_In]);
+      Expect([tk_op_In, tk_kw_To, tk_kw_DownTo], False, True);
     end;
-
-    if (Tokenizer.LastTok = tk_kw_DownTo) then
-      Result.WalkDown := True;
+    
+    case Tokenizer.LastTok of
+      tk_kw_DownTo: Result.LoopType := lptypes.loopDown;
+      tk_kw_To    : Result.LoopType := lptypes.loopUp;
+      tk_op_In    : Result.LoopType := lptypes.loopOver;
+    end;
+    
     Result.Limit := ParseExpression([], False);
 
     Expect([tk_kw_With, tk_kw_Do], False, False);

--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -1861,7 +1861,7 @@ function TLapeCompiler.ParseType(TypeForwards: TLapeTypeForwards; addToStackOwne
     Range: TLapeRange;
     RangeType: TLapeType;
   begin
-    TypeExpr := ParseTypeExpression([tk_sym_Equals, tk_op_Assign, tk_sym_ParenthesisClose, tk_sym_SemiColon], False);
+    TypeExpr := ParseTypeExpression([tk_sym_Equals, tk_op_Assign, tk_op_In, tk_sym_ParenthesisClose, tk_sym_SemiColon], False);
     try
       if (TypeExpr <> nil) and (TypeExpr is TLapeTree_Range) then
       begin
@@ -2000,9 +2000,8 @@ var
   isConst, wasShortCircuit: Boolean;
   Identifiers: TStringArray;
   VarType: TLapeType;
-  Default: TLapeTree_ExprBase;
-  DefVal: TLapeVar;
-  DefConstVal: TLapeGlobalVar;
+  DefExpr: TLapeTree_ExprBase;
+  DefConst: TLapeGlobalVar;
   VarDecl: TLapeVarDecl;
 begin
   Result := TLapeTree_VarList.Create(Self, getPDocPos());
@@ -2016,8 +2015,8 @@ begin
     Next();
     repeat
       VarType := nil;
-      Default := nil;
-      DefConstVal := nil;
+      DefExpr := nil;
+      DefConst := nil;
 
       Identifiers := ParseIdentifierList();
       Expect([tk_sym_Colon, tk_op_Assign, tk_sym_Equals], False, False);
@@ -2033,16 +2032,16 @@ begin
 
       if (Tokenizer.Tok = tk_sym_Equals) then
       begin
-        Default := ParseExpression([], True, False).setExpectedType(VarType) as TLapeTree_ExprBase;
-        if (Default <> nil) and (not Default.isConstant()) then
-          LapeException(lpeConstantExpected, Default.DocPos);
+        DefExpr := ParseExpression(ValidEnd, True, False).setExpectedType(VarType) as TLapeTree_ExprBase;
+        if (DefExpr <> nil) and (not DefExpr.isConstant()) then
+          LapeException(lpeConstantExpected, DefExpr.DocPos);
 
         try
           Expect(ValidEnd, False, False);
-          DefConstVal := Default.Evaluate();
+          DefConst := DefExpr.Evaluate();
         finally
-          if (Default <> nil) then
-            FreeAndNil(Default);
+          if (DefExpr <> nil) then
+            FreeAndNil(DefExpr);
         end;
       end
       else if (Tokenizer.Tok = tk_op_Assign) then
@@ -2050,15 +2049,15 @@ begin
         if (Length(Identifiers) <> 1) then
           LapeException(lpeDefaultToMoreThanOne, Tokenizer.DocPos);
 
-        Default := ParseExpression();
+        DefExpr := ParseExpression();
         Expect(ValidEnd, False, False);
       end;
 
       if (VarType = nil) then
-        if (DefConstVal <> nil) then
-          VarType := DefConstVal.VarType
-        else if (Default <> nil) then
-          VarType := Default.resType()
+        if (DefConst <> nil) then
+          VarType := DefConst.VarType
+        else if (DefExpr <> nil) then
+          VarType := DefExpr.resType()
         else
           LapeException(lpeCannotAssign, Tokenizer.DocPos);
       if (VarType = nil) or (VarType.Size < 1) then
@@ -2070,29 +2069,26 @@ begin
           LapeExceptionFmt(lpeDuplicateDeclaration, [Identifiers[i]], Tokenizer.DocPos);
 
         if isConst or VarType.IsStatic then
-          DefVal := TLapeVar(addLocalDecl(VarType.NewGlobalVarP(nil, Identifiers[i])))
+          VarDecl.VarDecl := TLapeVar(addLocalDecl(VarType.NewGlobalVarP(nil, Identifiers[i])))
         else
-          DefVal := addLocalVar(VarType, Identifiers[i]);
+          VarDecl.VarDecl := addLocalVar(VarType, Identifiers[i]);
 
-        if (DefConstVal <> nil) then
-          if (not (DefVal is TLapeGlobalVar)) or (VarType is TLapeType_Method) then
-          begin
-            VarDecl.VarDecl := DefVal;
-            VarDecl.Default := TLapeTree_GlobalVar.Create(DefConstVal, Self, GetPDocPos());
-            Result.addVar(VarDecl);
-          end
+        VarDecl.Default := nil;
+        if (DefConst <> nil) then
+          if (not (VarDecl.VarDecl is TLapeGlobalVar)) or (VarType is TLapeType_Method) then
+            VarDecl.Default := TLapeTree_GlobalVar.Create(DefConst, Self, GetPDocPos())
           else
-            DefVal.VarType.EvalConst(op_Assign, TLapeGlobalVar(DefVal), DefConstVal, [])
-        else if (Default <> nil) then
+            VarDecl.VarDecl.VarType.EvalConst(op_Assign, TLapeGlobalVar(VarDecl.VarDecl), DefConst, [])
+        else if (DefExpr <> nil) then
         begin
-          VarDecl.VarDecl := DefVal;
-          VarDecl.Default := Default;
-          Result.addVar(VarDecl);
-          Default := nil;
+          VarDecl.Default := DefExpr;
+          DefExpr := nil;
         end;
 
-        if (DefVal is TLapeVar) then
-          TLapeVar(DefVal).setReadWrite(isConst and (DefConstVal <> nil), not isConst);
+        if (VarDecl.VarDecl is TLapeVar) then
+          TLapeVar(VarDecl.VarDecl).setReadWrite(isConst and (DefConst <> nil), not isConst);
+
+        Result.addVar(VarDecl);
       end;
     until (Next() <> tk_Identifier) or OneOnly;
 
@@ -2100,8 +2096,8 @@ begin
       FOptions := FOptions + [lcoShortCircuit];
   except
     Result.Free();
-    if (Default <> nil) then
-      Default.Free();
+    if (DefExpr <> nil) then
+      DefExpr.Free();
     raise;
   end;
 end;
@@ -2704,12 +2700,14 @@ begin
 end;
 
 function TLapeCompiler.ParseFor(ExprEnd: EParserTokenSet = ParserToken_ExpressionEnd): TLapeTree_For;
+var
+  LimitType: TLapeType;
 begin
   Result := TLapeTree_For.Create(Self, getPDocPos());
 
   try
     if (lcoLooseSyntax in FOptions) and isNext([tk_kw_Var]) then
-      with ParseVarBlock(True, [tk_kw_To, tk_kw_DownTo]) do
+      with ParseVarBlock(True, [tk_op_In, tk_kw_To, tk_kw_DownTo]) do
       try
         if (Vars.Count <> 1) then
           LapeException(lpeVariableExpected, DocPos);
@@ -2739,8 +2737,12 @@ begin
       tk_kw_To    : Result.LoopType := lptypes.loopUp;
       tk_op_In    : Result.LoopType := lptypes.loopOver;
     end;
-    
-    Result.Limit := ParseExpression([], False);
+
+    LimitType := Result.Counter.resType();
+    if (Result.LoopType = lptypes.loopOver) then
+      LimitType := addManagedType(TLapeType_DynArray.Create(LimitType, Self, '', getPDocPos()));
+
+    Result.Limit := TLapeTree_ExprBase(ParseExpression([], False).setExpectedType(LimitType));
 
     Expect([tk_kw_With, tk_kw_Do], False, False);
     if (Tokenizer.Tok = tk_kw_With) then

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -145,6 +145,8 @@ type
   TLapeImportedProc = procedure(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
   TLapeImportedFunc = procedure(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 
+  ELoopType = (loopUp, loopDown, loopOver);
+  
   ELapeBaseType = (
     ltUnknown,
     ltUInt8, ltInt8, ltUInt16, ltInt16, ltUInt32, ltInt32, ltUInt64, ltInt64, //Integer
@@ -160,7 +162,7 @@ type
     ltScriptMethod, ltImportedMethod                                          //Methods
   );
   LapeIntegerTypeRange = ltUInt8..ltInt64;
-
+  
   EOperatorAssociative = (assocNone, assocLeft, assocRight);
   EOperator = (
     op_Unknown,

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -67,6 +67,7 @@ type
     function VarToString(AVar: Pointer): lpString; override;
     procedure VarUnique(var AVar: Pointer); overload; virtual;
     procedure VarUnique(AVar: TResVar; var Offset: Integer; Pos: PDocPos = nil); overload; virtual;
+    function VarLo(AVar: Pointer = nil): TLapeGlobalVar; override;
     function VarHi(AVar: Pointer = nil): TLapeGlobalVar; override;
 
     function NewGlobalVarStr(Str: AnsiString; AName: lpString = ''; ADocPos: PDocPos = nil): TLapeGlobalVar; override;
@@ -1103,6 +1104,14 @@ begin
   finally
     Free();
   end;
+end;
+
+function TLapeType_String.VarLo(AVar: Pointer = nil): TLapeGlobalVar;
+begin
+  if (FCompiler = nil) then
+    Result := nil
+  else
+    Result := FCompiler.getConstant(1);
 end;
 
 function TLapeType_String.VarHi(AVar: Pointer = nil): TLapeGlobalVar;

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -1119,7 +1119,7 @@ begin
   if (FCompiler = nil) or (AVar = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(Length(PString(AVar)^) - 1);
+    Result := FCompiler.getConstant(Length(PString(AVar)^));
 end;
 
 function TLapeType_String.NewGlobalVarStr(Str: AnsiString; AName: lpString = ''; ADocPos: PDocPos = nil): TLapeGlobalVar;

--- a/tests/ForIn.lap
+++ b/tests/ForIn.lap
@@ -1,0 +1,90 @@
+program new;
+{$assertions ON}
+{$define SILENT}
+
+procedure SilentWrite(str:String);
+begin
+  {$ifndef SILENT}
+  WriteLn(str);
+  {$ENDIF}
+end;
+
+
+var item:Int32;
+
+
+//============================================================================\\
+const staticArr: Array [3..7] of Int32 = [0,1,2,3,4];
+begin
+  SilentWrite('-----| static array |-----------------');
+  for item in staticArr do
+    SilentWrite('>>> ' + ToString(item));
+  Assert(item = staticArr[High(staticArr)]);
+end;
+
+
+//============================================================================\\
+var dynArr:Array of Int32 = [5..9];
+begin
+  SilentWrite('-----| dynamic array |----------------');
+  for item in dynArr do
+    SilentWrite('>>> ' + ToString(item));
+  Assert(item = dynArr[High(dynArr)]);
+end;
+
+
+//============================================================================\\
+begin
+  SilentWrite('-----| const static array |-----------');
+  for item in [1,2,3,4,5] do
+    SilentWrite('>>> '+ ToString(item));
+  Assert(item = 5);
+end;
+
+
+//============================================================================\\
+var
+  c:Char;
+  sstr:ShortString = 'shortstr';
+begin
+  SilentWrite('-----| shortstr  |---------------------');
+  for c in sstr do
+    SilentWrite('>>> ' + c);
+  Assert(c = 'r');
+end;
+
+
+//============================================================================\\
+var
+  ch:Char;
+  str:String = 'string';
+begin
+  SilentWrite('-----| string  |----------------------');
+  for ch in str do
+    SilentWrite('>>> ' + ch);
+  Assert(ch = 'g');
+end;
+
+
+//============================================================================\\
+var evalCount:Int32=0;
+function SideEffect(): Array of Int32;
+begin
+  Inc(evalCount);
+  Result := [5,4,3,2,1,0];
+end;
+
+begin
+  SilentWrite('-----| side effect |-----------');
+  for item in SideEffect() do
+    SilentWrite('>>> ' + ToString(item));
+  SilentWrite('SideEffect: ' + ToString(evalCount));
+  Assert(evalCount = 1);
+end;
+
+
+
+
+
+
+

--- a/tests/ForIn.lap
+++ b/tests/ForIn.lap
@@ -1,72 +1,64 @@
-program new;
+program TestForIn;
 {$assertions ON}
-{$define SILENT}
 
-procedure SilentWrite(str:String);
-begin
-  {$ifndef SILENT}
-  WriteLn(str);
-  {$ENDIF}
-end;
+var
+  item:Int32;
+  resStr:String;
 
-
-var item:Int32;
-
-
-//============================================================================\\
+//=================================================\\
 const staticArr: Array [3..7] of Int32 = [0,1,2,3,4];
 begin
-  SilentWrite('-----| static array |-----------------');
+  resStr := '';
   for item in staticArr do
-    SilentWrite('>>> ' + ToString(item));
-  Assert(item = staticArr[High(staticArr)]);
+    resStr := resStr + ToString(item);
+  Assert(resstr = '01234');
 end;
 
 
-//============================================================================\\
-var dynArr:Array of Int32 = [5..9];
+//=================================================\\
+var dynArr:Array of Int32 = [0..4];
 begin
-  SilentWrite('-----| dynamic array |----------------');
+  resStr := '';
   for item in dynArr do
-    SilentWrite('>>> ' + ToString(item));
-  Assert(item = dynArr[High(dynArr)]);
+    resStr := resStr + ToString(item);
+  Assert(resstr = '01234');
 end;
 
 
-//============================================================================\\
+//=================================================\\
 begin
-  SilentWrite('-----| const static array |-----------');
-  for item in [1,2,3,4,5] do
-    SilentWrite('>>> '+ ToString(item));
-  Assert(item = 5);
+  resStr := '';
+  for item in [0,1,2,3,4] do
+    resStr := resStr + ToString(item);
+  Assert(resStr = '01234');
 end;
 
 
-//============================================================================\\
+//=================================================\\
 var
   c:Char;
   sstr:ShortString = 'shortstr';
 begin
-  SilentWrite('-----| shortstr  |---------------------');
+  resStr := '';
   for c in sstr do
-    SilentWrite('>>> ' + c);
-  Assert(c = 'r');
+    resStr := resStr + c;
+  Assert(resStr = sstr);
 end;
 
 
-//============================================================================\\
+//=================================================\\
 var
   ch:Char;
   str:String = 'string';
 begin
-  SilentWrite('-----| string  |----------------------');
+  resStr := '';
   for ch in str do
-    SilentWrite('>>> ' + ch);
-  Assert(ch = 'g');
+    resStr := resStr + ch;
+  Assert(resStr = str);
 end;
 
 
-//============================================================================\\
+//===| Special tests |============================\\
 var evalCount:Int32=0;
 function SideEffect(): Array of Int32;
 begin
@@ -75,16 +67,18 @@ begin
 end;
 
 begin
-  SilentWrite('-----| side effect |-----------');
   for item in SideEffect() do
-    SilentWrite('>>> ' + ToString(item));
-  SilentWrite('SideEffect: ' + ToString(evalCount));
+    continue;
   Assert(evalCount = 1);
 end;
 
-
-
-
-
-
-
+//---| make sure locks are working |---\
+var
+  c1,c2,c3:Char;
+  text:string = 'abcdefg';
+begin
+  for c1 in str do
+    for c2 in str do
+      for c3 in str do ;
+  Assert((c1 = 'g') and (c2 = 'g') and (c3 = 'g'));
+end;


### PR DESCRIPTION
Adds support for iterating over arrays and strings.

```pascal
var
  item:Int32; 
  arr:Array of Int32 = [1,2,3,4];
begin
  for item in arr do
     WriteLn(item);
end;
```
> `Testing                   ForIn.lap :: Passed :: 11ms`