### PR TITLE
Operator overloading

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -1244,17 +1244,14 @@ begin
       if not Result.isOperator then
         Name := Tokenizer.TokString
       else begin
-        for op in OverloadableOperators do
-          if ParserTokenToOperator(Tokenizer.Tok) = op then
-          begin
-            Name := '!op_'+op_name[op];
-            break;
-          end;
-        if Length(Name) = 0 then 
+        op := ParserTokenToOperator(Tokenizer.Tok);
+        if (op in OverloadableOperators) then
+          Name := '!op_'+op_name[op]
+        else
           LapeExceptionFmt(lpeCannotOverloadOperator, [Tokenizer.TokString], Tokenizer.DocPos);
       end;
-        
-      if isNext([tk_sym_Dot, tk_sym_ParenthesisOpen], Token) and (Token = tk_sym_Dot) and (not Result.isOperator) then
+
+      if isNext([tk_sym_Dot, tk_sym_ParenthesisOpen], Token) and (Token = tk_sym_Dot) then
       begin
         Expect(tk_Identifier, True, False);
         Token := tk_NULL;
@@ -1331,7 +1328,7 @@ begin
         LapeExceptionFmt(lpeInvalidOperator, [op_name[op], 2], Pos);
       ltyp := Result.Params[0].VarType;
       rtyp := Result.Params[1].VarType;
-      if ValidEvalFunction(GetEvalProc(op, ltyp.BaseType, rtyp.BaseType)) then
+      if ltyp.EvalRes(op, rtyp) <> nil then
         LapeExceptionFmt(lpeCannotOverrideOperator, [op_name[op], ltyp.AsString, rtyp.AsString], Pos);
     end;
 

--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -1172,7 +1172,8 @@ begin
               DoBreak := (Tokenizer.LastTok = tk_sym_Dot) or StopAfterBeginEnd;
             end;
           tk_kw_Const, tk_kw_Var: Statement := ParseVarBlock();
-          tk_kw_Function, tk_kw_Procedure: addDelayedExpression(ParseMethod(FuncForwards));
+          tk_kw_Function, tk_kw_Procedure, tk_kw_Operator: 
+            addDelayedExpression(ParseMethod(FuncForwards));
           tk_kw_Type: ParseTypeBlock();
 
           {$IFDEF Lape_PascalLabels}
@@ -1228,18 +1229,31 @@ var
   Param: TLapeParameter;
   Token: EParserToken;
   Default: TLapeTree_ExprBase;
+  op: EOperator;
 begin
   Pos := Tokenizer.DocPos;
-  isFunction := (Tokenizer.Tok = tk_kw_Function);
   Result := TLapeType_Method.Create(Self, nil, nil, '', @Pos);
-
+  Result.isOperator := (Tokenizer.Tok = tk_kw_Operator);
+  isFunction := (Tokenizer.Tok = tk_kw_Function);
+  
   try
-
-    if isNext([tk_Identifier, tk_sym_ParenthesisOpen], Token) and (Token = tk_Identifier) then
+    if (isNext([tk_Identifier, tk_sym_ParenthesisOpen], Token) and (Token = tk_Identifier)) or
+       (Result.isOperator and isNext(ParserToken_Operators, Token)) then
     begin
-      Name := Tokenizer.TokString;
-
-      if isNext([tk_sym_Dot, tk_sym_ParenthesisOpen], Token) and (Token = tk_sym_Dot) then
+      if not Result.isOperator then
+        Name := Tokenizer.TokString
+      else begin
+        for op in OverloadableOperators do
+          if op_str[op] = Tokenizer.TokString then
+          begin
+            Name := '!op_'+op_name[op];
+            break;
+          end;
+        if Length(Name) = 0 then 
+          LapeExceptionFmt(lpeCannotOverloadOperator, [Tokenizer.TokString], Tokenizer.DocPos);
+      end;
+        
+      if isNext([tk_sym_Dot, tk_sym_ParenthesisOpen], Token) and (Token = tk_sym_Dot) and (not Result.isOperator) then
       begin
         Expect(tk_Identifier, True, False);
         Token := tk_NULL;
@@ -1310,7 +1324,10 @@ begin
         end;
       until (Tokenizer.Tok = tk_sym_ParenthesisClose);
 
-    if isFunction then
+    if Result.isOperator and (Result.Params.Count <> 2) then
+      LapeExceptionFmt(lpeInvalidOperator, [op_name[op], 2], Pos);
+
+    if isFunction or Result.isOperator then
     begin
       Expect(tk_sym_Colon, True, False);
       Result.Res := ParseType(nil);
@@ -1433,9 +1450,10 @@ begin
     end;
 
     try
-      if (Tokenizer.Tok = tk_kw_Overload) then
+      if (Tokenizer.Tok = tk_kw_Overload) or FuncHeader.isOperator then
       begin
-        ParseExpressionEnd(tk_sym_SemiColon, True, False);
+        if not FuncHeader.isOperator then
+          ParseExpressionEnd(tk_sym_SemiColon, True, False);
 
         if (OldDeclaration = nil) or (not LocalDecl) or ((OldDeclaration is TLapeGlobalVar) and (TLapeGlobalVar(OldDeclaration).VarType is TLapeType_Method)) then
           with TLapeType_OverloadedMethod(addLocalDecl(TLapeType_OverloadedMethod.Create(Self, '', @Pos), FStackInfo.Owner)) do
@@ -1814,7 +1832,7 @@ function TLapeCompiler.ParseType(TypeForwards: TLapeTypeForwards; addToStackOwne
       else if (Tokenizer.Tok = tk_kw_Private) then
         BaseType := ltScriptMethod;
 
-      Expect([tk_kw_Function, tk_kw_Procedure], True, False);
+      Expect([tk_kw_Function, tk_kw_Procedure, tk_kw_Operator], True, False);
     end;
 
     Result := ParseMethodHeader(Name, False);
@@ -1921,7 +1939,7 @@ begin
         end;
       tk_sym_Caret: ParsePointer();
       tk_sym_ParenthesisOpen: ParseEnum();
-      tk_kw_Function, tk_kw_Procedure,
+      tk_kw_Function, tk_kw_Procedure, tk_kw_Operator,
       tk_kw_External, {tk_kw_Export,} tk_kw_Private: ParseMethodType();
       tk_kw_Type: ParseTypeType();
       else ParseDef();
@@ -3552,7 +3570,7 @@ begin
   OldState := getTempTokenizerState(AHeader + ';', '!addGlobalFuncHdr');
 
   try
-    Expect([tk_kw_Function, tk_kw_Procedure]);
+    Expect([tk_kw_Function, tk_kw_Procedure, tk_kw_Operator]);
     Method := ParseMethod(nil, True);
     CheckAfterCompile();
 

--- a/lpexceptions.pas
+++ b/lpexceptions.pas
@@ -31,6 +31,7 @@ const
   lpeCannotEvalRunTime = 'Cannot be evaluated at runtime';
   lpeCannotInvoke = 'Cannot invoke identifier';
   lpeCannotOverload = 'Cannot overload function';
+  lpeCannotOverloadOperator = 'Cannot overload operator "%s"';
   lpeClosingParenthesisExpected = 'Closing parenthesis expected';
   lpeConditionalNotClosed = 'Conditional statement not properly closed';
   lpeConstantExpected = 'Constant expression expected';
@@ -57,6 +58,7 @@ const
   lpeInvalidIndex = 'Invalid index "%s"';
   lpeInvalidIterator = 'Variable cannot be used for iteration';
   lpeInvalidJump = 'Invalid jump';
+  lpeInvalidOperator = 'Operator "%s" expects %d parameters';
   lpeInvalidRange = 'Expression is not a valid range';
   lpeInvalidUnionType = 'Invalid union type';
   lpeInvalidValueForType = 'Invalid value for type "%s"';

--- a/lpexceptions.pas
+++ b/lpexceptions.pas
@@ -32,6 +32,7 @@ const
   lpeCannotInvoke = 'Cannot invoke identifier';
   lpeCannotOverload = 'Cannot overload function';
   lpeCannotOverloadOperator = 'Cannot overload operator "%s"';
+  lpeCannotOverrideOperator = 'Cannot override operator "%s" with types "%s" and "%s"';
   lpeClosingParenthesisExpected = 'Closing parenthesis expected';
   lpeConditionalNotClosed = 'Conditional statement not properly closed';
   lpeConstantExpected = 'Constant expression expected';

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -46,6 +46,7 @@ type
     {$IFDEF Lape_PascalLabels}tk_kw_Label,{$ENDIF}
     tk_kw_Of,
     tk_kw_Object,
+    tk_kw_Operator,
     tk_kw_Out,
     tk_kw_Overload,
     tk_kw_Override,
@@ -238,7 +239,7 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..45 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..46 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';          Token: tk_op_AND),
       (Keyword: 'DIV';          Token: tk_op_DIV),
       (Keyword: 'IN';           Token: tk_op_IN),
@@ -269,6 +270,7 @@ const
       (Keyword: 'LABEL';        Token: tk_kw_Label),
       {$ENDIF}
       (Keyword: 'OBJECT';       Token: tk_kw_Object),
+      (Keyword: 'OPERATOR';     Token: tk_kw_Operator),
       (Keyword: 'OF';           Token: tk_kw_Of),
       (Keyword: 'OUT';          Token: tk_kw_Out),
       (Keyword: 'OVERLOAD';     Token: tk_kw_Overload),

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -584,6 +584,8 @@ const
   LabelOperators = CompareOperators;
   EnumOperators = [op_Plus, op_Minus, op_Assign] + CompareOperators;
 
+  OverloadableOperators = [op_Assign, op_Plus, op_Minus, op_Multiply, op_Divide, op_DIV, op_Power, op_MOD, op_IN, op_SHL, op_SHR] + CompareOperators + BinaryOperators; 
+  
   op_str: array[EOperator] of lpString = ('',
     '=', '>', '>=', '<', '<=', '<>', '@', 'and', ':=', '^', 'div', '/', '.' , 'in',
     '[', '-', 'mod', '*', 'not', 'or', '+', '**', 'shl', 'shr', 'xor', '-', '+');

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -1823,7 +1823,6 @@ begin
       EvalProc := nil;
 
     if (not Result.HasType()) or (not ValidEvalFunction(EvalProc)) then
-    try
       if (op = op_Dot) and ValidFieldName(Right) then
         Exit(EvalDot(PlpString(Right.VarPos.GlobalVar.Ptr)^))
       else if (op = op_Assign) and Right.HasType() then
@@ -1843,18 +1842,7 @@ begin
         LapeExceptionFmt(lpeIncompatibleOperator1, [LapeOperatorToString(op), AsString])
       else
         LapeExceptionFmt(lpeIncompatibleOperator, [LapeOperatorToString(op)]);
-    except
-      on e: Exception do
-      begin
-        Dest := NullResVar;
-        Result := TryOperatorOverload();
-        if not Result.HasType() then
-          LapeException(e.Message)
-        else 
-          Exit;
-      end;
-    end;
-    
+
     FCompiler.getDestVar(Dest, Result, op);
 
     if (op = op_Assign) then

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -689,7 +689,7 @@ implementation
 uses
   {$IFDEF Lape_NeedAnsiStringsUnit}AnsiStrings,{$ENDIF}
   lpvartypes_ord, lpvartypes_array,
-  lpexceptions, lpeval, lpinterpreter, lptree;
+  lpexceptions, lpeval, lpinterpreter;
 
 function getTypeArray(Arr: array of TLapeType): TLapeTypeArray;
 var
@@ -1775,20 +1775,6 @@ function TLapeType.Eval(Op: EOperator; var Dest: TResVar; Left, Right: TResVar; 
       FCompiler.Emitter._Eval(getEvalProc(op_Dot, ltUnknown, ltPointer), Res, Result, Left, Offset, Pos);
       Result := Res;
     end;
-  end;
-
-  function TryOperatorOverload(): TResVar;
-  begin
-    Result := NullResVar;
-    if (op in OverloadableOperators) and Right.HasType() and Left.HasType() and (not(op in UnaryOperators)) then
-      with TLapeTree_InternalMethod_Operator.Create(op, FCompiler, Pos) do
-      try
-        addParam(TLapeTree_ResVar.Create(Left, FCompiler, Pos));
-        addParam(TLapeTree_ResVar.Create(Right, FCompiler, Pos));
-        Result := Compile(Offset);
-      finally 
-        Free();
-      end;
   end;
   
 var

--- a/tests/OpOverload.lap
+++ b/tests/OpOverload.lap
@@ -30,7 +30,7 @@ begin
   a := [9,9];
   b := [2,2];
   Assert((a = b) = False);
-  Assert(UInt64(a + b)   = UInt64([11,11]));
-  Assert(UInt64(a - b)   = UInt64([7,7]));
-  Assert(UInt64(a xor b) = UInt64([11,11]));
-end; 
+  Assert(UInt64(a + b)   = UInt64(TPoint([11,11])));
+  Assert(UInt64(a - b)   = UInt64(TPoint([7,7])));
+  Assert(UInt64(a xor b) = UInt64(TPoint([11,11])));
+end;

--- a/tests/OpOverload.lap
+++ b/tests/OpOverload.lap
@@ -1,0 +1,36 @@
+{$assertions ON}
+type
+  TPoint = record x,y:Int32; end;
+
+operator = (Left,Right:TPoint): Boolean;
+begin
+  Result := (Left.x = Right.x) and (Left.y = Right.y);
+end;
+
+operator + (Left,Right:TPoint): TPoint;
+begin
+  Result.x := (Left.x + Right.x);
+  Result.y := (Left.y + Right.y);
+end;
+
+operator - (Left,Right:TPoint): TPoint;
+begin
+  Result.x := (Left.x - Right.x);
+  Result.y := (Left.y - Right.y);
+end;
+
+operator xor (Left,Right:TPoint): TPoint;
+begin
+  Result.x := (Left.x xor Right.x);
+  Result.y := (Left.y xor Right.y);
+end;
+
+var a,b:TPoint;
+begin
+  a := [9,9];
+  b := [2,2];
+  Assert((a = b) = False);
+  Assert(UInt64(a + b)   = UInt64([11,11]));
+  Assert(UInt64(a - b)   = UInt64([7,7]));
+  Assert(UInt64(a xor b) = UInt64([11,11]));
+end; 


### PR DESCRIPTION
Adds support for FPC-like operator overloading. 

Notes:
- Doesn't allow unary operators to be overloaded.
- Doesn't support overriding builtin operators.