### PR TITLE
Compound assignment operators

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -877,6 +877,8 @@ var
         Result := (lcoScopedEnums in FOptions)
       else if (Def = 'continuecase') then
         Result := (lcoContinueCase in FOptions)
+      else if (Def = 'coperators') then
+        Result := (lcoCOperators in FOptions)
       else
         Result := False;
     end;
@@ -1022,6 +1024,8 @@ begin
     setOption(lcoScopedEnums)
   else if (Directive = 'continuecase') then
     setOption(lcoContinueCase)
+  else if (Directive = 'coperators') then
+    setOption(lcoCOperators)
   else
     Result := False;
 end;

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -79,6 +79,10 @@ type
     tk_op_Addr,
     tk_op_AND,
     tk_op_Assign,
+    tk_op_AssignDiv,
+    tk_op_AssignMinus,
+    tk_op_AssignMul,
+    tk_op_AssignPlus,
     tk_op_Deref,
     tk_op_DIV,
     tk_op_Divide,
@@ -306,6 +310,10 @@ const
     assocRight,                         //op_Addr
     assocLeft,                          //op_AND
     assocRight,                         //op_Assign
+    assocRight,                         //op_AssignDiv
+    assocRight,                         //op_AssignMinus
+    assocRight,                         //op_AssignMul
+    assocRight,                         //op_AssignPlus
     assocLeft,                          //op_Deref
     assocLeft,                          //op_DIV
     assocLeft,                          //op_Divide
@@ -340,6 +348,10 @@ const
     2,                                  //op_Addr
     5,                                  //op_AND
     8,                                  //op_Assign
+    8,                                  //op_AssignDiv
+    8,                                  //op_AssignMinus
+    8,                                  //op_AssignMul
+    8,                                  //op_AssignPlus
     1,                                  //op_Deref
     5,                                  //op_DIV
     5,                                  //op_Divide
@@ -834,29 +846,58 @@ begin
         else
           Result := setTok(tk_sym_Colon);
       end;
+    
+    {Divide, Comment, AssignDiv}
     '/':
-      begin
-        if (getChar(1) = '/') then
-        begin
-          Inc(FPos);
-          while (not (getChar(1) in [#13, #10, #0])) do Inc(FPos);
-          Result := setTok(tk_Comment);
-        end
+      case getChar(1) of
+        '/': 
+          begin
+            Inc(FPos);
+            while (not (getChar(1) in [#13, #10, #0])) do Inc(FPos);
+            Result := setTok(tk_Comment);
+          end;
+        '=':
+          begin
+            Result := setTok(tk_op_AssignDiv);
+            Inc(FPos);
+          end;
         else
           Result := setTok(tk_op_Divide);
       end;
-    '-': Result := setTok(tk_op_Minus);
-    '*':
-      begin
-        if (getChar(1) = '*') then
-        begin
-          Result := setTok(tk_op_Power);
+          
+ 
+    {Minus, AssignMinus} 
+    '-':if (getChar(1) = '=') then begin
+          Result := setTok(tk_op_AssignMinus);
           Inc(FPos);
-        end
+        end else 
+          Result := setTok(tk_op_Minus);
+    
+    {Multiply, Power, AssignMul}      
+    '*':
+      case getChar(1) of
+        '*':
+          begin
+            Inc(FPos);
+            Result := setTok(tk_op_Power);
+          end;
+        '=': 
+          begin
+            Result := setTok(tk_op_AssignMul);
+            Inc(FPos);
+          end;
         else
           Result := setTok(tk_op_Multiply);
       end;
-    '+': Result := setTok(tk_op_Plus);
+      
+    
+    {Plus, AssignPlus}
+    '+':if (getChar(1) = '=') then begin
+          Result := setTok(tk_op_AssignPlus);
+          Inc(FPos);
+        end else 
+          Result := setTok(tk_op_Plus);
+    
     '@': Result := setTok(tk_op_Addr);
     '^': Result := setTok(tk_sym_Caret);
 

--- a/lptree.pas
+++ b/lptree.pas
@@ -4392,7 +4392,7 @@ begin
       else
         LeftVar := nil;
 
-      if (FOperatorType = op_Assign) and ((LeftVar = nil) or (not LeftVar.Writeable)) then
+      if (FOperatorType in [op_Assign]+CompoundOperators) and ((LeftVar = nil) or (not LeftVar.Writeable)) then
         LapeException(lpeCannotAssign, [FLeft, Self]);
 
       if (LeftVar <> nil) and (not isEmpty(FRight)) then
@@ -4493,7 +4493,7 @@ begin
   else
     LeftVar := NullResVar;
 
-  if (FOperatorType = op_Assign) and (not LeftVar.Writeable) then
+  if (FOperatorType in [op_Assign]+CompoundOperators) and (not LeftVar.Writeable) then
     LapeException(lpeCannotAssign, [FLeft, Self]);
 
   if (FRight <> nil) then
@@ -4502,10 +4502,10 @@ begin
     if (FOperatorType = op_Index) then
       FRight := FRight.setExpectedType(FCompiler.getBaseType(ltInt32)) as TLapeTree_ExprBase;
 
-    if (FOperatorType = op_Assign) and
-      (FLeft <> nil) and LeftVar.Writeable and
-      (FRight is TLapeTree_DestExprBase) and
-      (TLapeTree_DestExprBase(FRight).Dest.VarPos.MemPos = NullResVar.VarPos.MemPos)
+    if (FOperatorType in [op_Assign]+CompoundOperators) and
+       (FLeft <> nil) and LeftVar.Writeable and
+       (FRight is TLapeTree_DestExprBase) and
+       (TLapeTree_DestExprBase(FRight).Dest.VarPos.MemPos = NullResVar.VarPos.MemPos)
     then
     begin
       TLapeTree_DestExprBase(FRight).Dest := LeftVar;

--- a/lptree.pas
+++ b/lptree.pas
@@ -4197,7 +4197,7 @@ begin
     Result := (not isEmpty(FParent)) and (FParent is TLapeTree_Operator) and (
       (
         (TLapeTree_Operator(FParent).FLeft = Self) and
-        (TLapeTree_Operator(FParent).OperatorType = op_Assign)
+        (TLapeTree_Operator(FParent).OperatorType in [op_Assign]+CompoundOperators)
       ) or (
         (TLapeTree_Operator(FParent).FLeft <> Self) and
         TLapeTree_Operator(FParent).isAssigning()

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -178,6 +178,10 @@ type
     op_Addr,
     op_AND,
     op_Assign,
+    op_AssignDiv,
+    op_AssignMinus,
+    op_AssignMul,
+    op_AssignPlus,
     op_Deref,
     op_DIV,
     op_Divide,
@@ -581,14 +585,19 @@ const
   LabelOperators = CompareOperators;
   EnumOperators = [op_Plus, op_Minus, op_Assign] + CompareOperators;
 
-  OverloadableOperators = [op_Assign, op_Plus, op_Minus, op_Multiply, op_Divide, op_DIV, op_Power, op_MOD, op_IN, op_SHL, op_SHR] + CompareOperators + BinaryOperators; 
-  
+  CompoundOperators = [op_AssignPlus, op_AssignMinus, op_AssignDiv, op_AssignMul];
+  OverloadableOperators = [op_Assign, op_Plus, op_Minus, op_Multiply, op_Divide, op_DIV, op_Power, op_MOD, op_IN, op_SHL, op_SHR] + CompareOperators + BinaryOperators + CompoundOperators; 
+
   op_str: array[EOperator] of lpString = ('',
-    '=', '>', '>=', '<', '<=', '<>', '@', 'and', ':=', '^', 'div', '/', '.' , 'in',
-    '[', '-', 'mod', '*', 'not', 'or', '+', '**', 'shl', 'shr', 'xor', '-', '+');
+    '=', '>', '>=', '<', '<=', '<>', '@', 'and', ':=', '/=', '-=', '*=', '+=', 
+    '^', 'div', '/', '.' , 'in', '[', '-', 'mod', '*', 'not', 'or', '+', '**', 
+    'shl', 'shr', 'xor', '-', '+'
+  );
   op_name: array[EOperator] of lpString = ('',
-    'EQ', 'GT', 'GTEQ', 'LT', 'LTEQ', 'NEQ', 'ADDR', 'AND', 'ASGN', 'DEREF', 'IDIV', 'DIV', 'DOT',
-    'IN', 'IDX', 'SUB', 'MOD', 'MUL', 'NOT', 'OR', 'ADD', 'POW', 'SHL', 'SHR', 'XOR', 'UMIN', 'UPOS');
+    'EQ', 'GT', 'GTEQ', 'LT', 'LTEQ', 'NEQ', 'ADDR', 'AND', 'ASGN', 'DIVASGN', 'SUBASGN', 'MULASGN', 'ADDASGN', 
+    'DEREF', 'IDIV', 'DIV', 'DOT', 'IN', 'IDX', 'SUB', 'MOD', 'MUL', 'NOT', 'OR', 'ADD', 'POW', 
+    'SHL', 'SHR', 'XOR', 'UMIN', 'UPOS'
+  );
 
 var
   lowUInt8: UInt8 = Low(UInt8);    highUInt8: UInt8 = High(UInt8);


### PR DESCRIPTION
Added {$COPERATORS}-switch which allows to toggle ON/OFF C-like assignment operators. By default this switch is toggled `ON`.

Supports the following operators:
* `i += 3;`  Add 3 to I and assign the result to I;
* `i -= 2;`  Subtract 2 from I and assign the result to I;
* `i *= 2;`  Multiply I with 2 and assign the result to I;
* `i /= 2;`  Divide I with 2 and assign the result to I;

Operators also supports overloading.