### PR TITLE
Multiline strings requires double-quote

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -2235,11 +2235,11 @@ var
   begin
     DocPos := Tokenizer.DocPos;
     case Tokenizer.Tok of
-      tk_typ_String: Str := getString();
+      tk_typ_String, tk_typ_HereString: Str := getString();
       tk_typ_Char: Str := lpString(Tokenizer.TokChar);
       else LapeException(lpeImpossible);
     end;
-    while isNext([tk_typ_String, tk_typ_Char], Token) do
+    while isNext([tk_typ_String, tk_typ_HereString, tk_typ_Char], Token) do
     begin
       case Token of
         tk_typ_String:
@@ -2247,8 +2247,15 @@ var
             Str := Str + #39 + getString()
           else
             Str := Str + getString();
-        tk_typ_Char: Str := Str + lpString(Tokenizer.TokChar);
-        else LapeException(lpeImpossible);
+        tk_typ_HereString:
+          if (Tokenizer.LastTok = tk_typ_HereString) then
+            Str := Str + #34 + getString()
+          else
+            Str := Str + getString();
+        tk_typ_Char: 
+          Str := Str + lpString(Tokenizer.TokChar);
+        else 
+          LapeException(lpeImpossible);
       end;
       ForceString := True;
     end;
@@ -2431,7 +2438,8 @@ begin
         tk_typ_Integer_Bin: PushVarStack(TLapeTree_Integer.Create(lpString(UIntToStr(Tokenizer.TokUInt64)), Self, getPDocPos()));
         tk_typ_Float: PushVarStack(TLapeTree_Float.Create(Tokenizer.TokString, Self, getPDocPos()));
         tk_typ_Char,
-        tk_typ_String: ParseAndPushString();
+        tk_typ_String,
+        tk_typ_HereString: ParseAndPushString();
 
         tk_Identifier:
           begin

--- a/lpexceptions.pas
+++ b/lpexceptions.pas
@@ -39,6 +39,7 @@ const
   lpeDeclarationOutOfScope = 'Declaration "%s" out of scope';
   lpeDefaultToMoreThanOne = 'Runtime default value can only be assigned to one variable';
   lpeDuplicateDeclaration = 'Duplicate declaration "%s"';
+  lpeErrorScanningString = '%s while scanning string literal';
   lpeExceptionAt = '%s at line %d, column %d';
   lpeExceptionIn = '%s in file "%s"';
   lpeExpected = '%s expected';


### PR DESCRIPTION
Multiline strings ("Heredoc") now requires double-quote <">. Single-line strings follow pascal-standard using single-quote. This feature is supported (equally) in dwscript, and oxygene/prism.

Better error-handling when strings are missing ending quotes.