### PR TITLE
Can override previously declared operators & adds the "is"-operator

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -1459,7 +1459,7 @@ begin
     end;
 
     try
-      if (Tokenizer.Tok = tk_kw_Overload) or FuncHeader.isOperator then
+      if (Tokenizer.Tok = tk_kw_Overload) or (FuncHeader.isOperator and (Tokenizer.Tok <> tk_kw_Override)) then
       begin
         if not FuncHeader.isOperator then
           ParseExpressionEnd(tk_sym_SemiColon, True, False);

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -88,6 +88,7 @@ type
     tk_op_Divide,
     tk_op_Dot,
     tk_op_IN,
+    tk_op_IS,
     tk_op_Index,
     tk_op_Minus,
     tk_op_MOD,
@@ -244,10 +245,11 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..46 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..47 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';          Token: tk_op_AND),
       (Keyword: 'DIV';          Token: tk_op_DIV),
       (Keyword: 'IN';           Token: tk_op_IN),
+      (Keyword: 'IS';           Token: tk_op_IS),
       (Keyword: 'MOD';          Token: tk_op_MOD),
       (Keyword: 'NOT';          Token: tk_op_NOT),
       (Keyword: 'OR';           Token: tk_op_OR),
@@ -320,6 +322,7 @@ const
     assocLeft,                          //op_Divide
     assocLeft,                          //op_Dot
     assocLeft,                          //op_IN
+    assocLeft,                          //op_IS
     assocLeft,                          //op_Index
     assocLeft,                          //op_Minus
     assocLeft,                          //op_MOD
@@ -358,6 +361,7 @@ const
     5,                                  //op_Divide
     1,                                  //op_Dot
     7,                                  //op_IN
+    7,                                  //op_IS
     1,                                  //op_Index
     6,                                  //op_Minus
     5,                                  //op_MOD

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -146,7 +146,7 @@ type
   TLapeImportedFunc = procedure(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 
   ELoopType = (loopUp, loopDown, loopOver);
-  
+
   ELapeBaseType = (
     ltUnknown,
     ltUInt8, ltInt8, ltUInt16, ltInt16, ltUInt32, ltInt32, ltUInt64, ltInt64, //Integer
@@ -162,7 +162,7 @@ type
     ltScriptMethod, ltImportedMethod                                          //Methods
   );
   LapeIntegerTypeRange = ltUInt8..ltInt64;
-  
+
   EOperatorAssociative = (assocNone, assocLeft, assocRight);
   EOperator = (
     op_Unknown,
@@ -187,6 +187,7 @@ type
     op_Divide,
     op_Dot,
     op_IN,
+    op_IS,
     op_Index,
     op_Minus,
     op_MOD,
@@ -586,17 +587,17 @@ const
   EnumOperators = [op_Plus, op_Minus, op_Assign] + CompareOperators;
 
   CompoundOperators = [op_AssignPlus, op_AssignMinus, op_AssignDiv, op_AssignMul];
-  OverloadableOperators = [op_Assign, op_Plus, op_Minus, op_Multiply, op_Divide, op_DIV, op_Power, op_MOD, op_IN, op_SHL, op_SHR] + CompareOperators + BinaryOperators + CompoundOperators; 
+  OverloadableOperators = [op_Assign, op_Plus, op_Minus, op_Multiply, op_Divide, op_DIV, op_Power, op_MOD, op_IN, op_IS, op_SHL, op_SHR] + CompareOperators + BinaryOperators + CompoundOperators;
 
   op_str: array[EOperator] of lpString = ('',
-    '=', '>', '>=', '<', '<=', '<>', '@', 'and', ':=', '/=', '-=', '*=', '+=', 
-    '^', 'div', '/', '.' , 'in', '[', '-', 'mod', '*', 'not', 'or', '+', '**', 
-    'shl', 'shr', 'xor', '-', '+'
+    '=', '>', '>=', '<', '<=', '<>', '@', 'and', ':=', '/=', '-=', '*=', '+=',
+    '^', 'div', '/', '.' , 'in', 'is', '[', '-', 'mod', '*', 'not', 'or', '+',
+    '**', 'shl', 'shr', 'xor', '-', '+'
   );
   op_name: array[EOperator] of lpString = ('',
-    'EQ', 'GT', 'GTEQ', 'LT', 'LTEQ', 'NEQ', 'ADDR', 'AND', 'ASGN', 'DIVASGN', 'SUBASGN', 'MULASGN', 'ADDASGN', 
-    'DEREF', 'IDIV', 'DIV', 'DOT', 'IN', 'IDX', 'SUB', 'MOD', 'MUL', 'NOT', 'OR', 'ADD', 'POW', 
-    'SHL', 'SHR', 'XOR', 'UMIN', 'UPOS'
+    'EQ', 'GT', 'GTEQ', 'LT', 'LTEQ', 'NEQ', 'ADDR', 'AND', 'ASGN', 'DIVASGN', 'SUBASGN', 'MULASGN', 'ADDASGN',
+    'DEREF', 'IDIV', 'DIV', 'DOT', 'IN', 'IS', 'IDX', 'SUB', 'MOD', 'MUL', 'NOT', 'OR', 'ADD',
+    'POW', 'SHL', 'SHR', 'XOR', 'UMIN', 'UPOS'
   );
 
 var


### PR DESCRIPTION
This is a small change, with two additions, both related to operator overloading: 

``` pascal
operator * (Left:String; Right:Int32): String;
begin
  for 0 to Right do Result += Left;
end;

operator * (Left:String; Right:Int32): String; override;
begin
  Result := '>>> ' + inherited;
end; 
```

Also added the `is` operator, which currently serves no other purpose than overloading.