### PR TITLE
Deprecated hints

### DIFF
--- a/extensions/ffi/lpffi.pas
+++ b/extensions/ffi/lpffi.pas
@@ -93,7 +93,7 @@ implementation
 
 uses
   {$IFDEF FPC}dynlibs{$ELSE}Windows{$ENDIF},
-  lpexceptions;
+  lpmessages;
 
 {$IFNDEF FPC}
 type

--- a/extensions/ffi/lpffiwrappers.pas
+++ b/extensions/ffi/lpffiwrappers.pas
@@ -189,7 +189,7 @@ function _ParseMethodHeader(Compiler: TLapeCompiler; Header: lpString): TLapeTyp
 implementation
 
 uses
-  lpexceptions, lpparser, lpeval, lpinterpreter, lpvartypes_array, lpvartypes_record;
+  lpmessages, lpparser, lpeval, lpinterpreter, lpvartypes_array, lpvartypes_record;
 
 const
   PowerTwoRegs = [SizeOf(UInt8), SizeOf(UInt16), SizeOf(UInt32), SizeOf(UInt64)];

--- a/extensions/ffi/test/LapeTestFFI.lpr
+++ b/extensions/ffi/test/LapeTestFFI.lpr
@@ -2,7 +2,7 @@ program LapeTestFFI;
 
 uses
   SysUtils, {$IFDEF FPC}LCLIntf,{$ELSE}{$IFDEF MSWINDOWS}Windows,{$ENDIF}{$ENDIF}
-  lptypes, lpvartypes, lpcompiler, lptree, lpparser, lpinterpreter, lpexceptions,
+  lptypes, lpvartypes, lpcompiler, lptree, lpparser, lpinterpreter, lpmessages,
   lpffiwrappers, ffi;
 
 type

--- a/lape.lpi
+++ b/lape.lpi
@@ -196,207 +196,207 @@
         <IsPartOfProject Value="True"/>
       </Unit6>
       <Unit7>
-        <Filename Value="lpexceptions.pas"/>
+        <Filename Value="lape.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit7>
       <Unit8>
-        <Filename Value="lape.inc"/>
+        <Filename Value="lpvartypes.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit8>
       <Unit9>
-        <Filename Value="lpvartypes.pas"/>
+        <Filename Value="lpcodeemitter.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit9>
       <Unit10>
-        <Filename Value="lpcodeemitter.pas"/>
+        <Filename Value="lpeval_arr.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit10>
       <Unit11>
-        <Filename Value="lpeval_arr.inc"/>
+        <Filename Value="lpeval_res.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit11>
       <Unit12>
-        <Filename Value="lpeval_res.inc"/>
+        <Filename Value="lpeval_functions.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit12>
       <Unit13>
-        <Filename Value="lpeval_functions.inc"/>
+        <Filename Value="lpcodeemitter_evalheader.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit13>
       <Unit14>
-        <Filename Value="lpcodeemitter_evalheader.inc"/>
+        <Filename Value="lpcodeemitter_evalbody.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit14>
       <Unit15>
-        <Filename Value="lpcodeemitter_evalbody.inc"/>
+        <Filename Value="lpcodeemitter_evalcase.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit15>
       <Unit16>
-        <Filename Value="lpcodeemitter_evalcase.inc"/>
+        <Filename Value="lpinterpreter_doeval.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit16>
       <Unit17>
-        <Filename Value="lpinterpreter_doeval.inc"/>
+        <Filename Value="lpinterpreter_evalcase.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit17>
       <Unit18>
-        <Filename Value="lpinterpreter_evalcase.inc"/>
+        <Filename Value="lpinterpreter_evalrecords.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit18>
       <Unit19>
-        <Filename Value="lpinterpreter_evalrecords.inc"/>
+        <Filename Value="lpinterpreter_evalopcodes.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit19>
       <Unit20>
-        <Filename Value="lpinterpreter_evalopcodes.inc"/>
+        <Filename Value="lpinterpreter_jumpopcodes.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit20>
       <Unit21>
-        <Filename Value="lpinterpreter_jumpopcodes.inc"/>
+        <Filename Value="lpinterpreter_jumprecords.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit21>
       <Unit22>
-        <Filename Value="lpinterpreter_jumprecords.inc"/>
+        <Filename Value="lpinterpreter_dojump.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit22>
       <Unit23>
-        <Filename Value="lpinterpreter_dojump.inc"/>
+        <Filename Value="lpinterpreter_jumpcase.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit23>
       <Unit24>
-        <Filename Value="lpinterpreter_jumpcase.inc"/>
+        <Filename Value="lpcodeemitter_jumpheader.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit24>
       <Unit25>
-        <Filename Value="lpcodeemitter_jumpheader.inc"/>
+        <Filename Value="lpcodeemitter_jumpbody.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit25>
       <Unit26>
-        <Filename Value="lpcodeemitter_jumpbody.inc"/>
+        <Filename Value="lptree.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit26>
       <Unit27>
-        <Filename Value="lptree.pas"/>
+        <Filename Value="lpinterpreter_opcodecase.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit27>
       <Unit28>
-        <Filename Value="lpinterpreter_opcodecase.inc"/>
+        <Filename Value="lpdisassembler.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit28>
       <Unit29>
-        <Filename Value="lpdisassembler.pas"/>
+        <Filename Value="lpdisassembler_dojump.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit29>
       <Unit30>
-        <Filename Value="lpdisassembler_dojump.inc"/>
+        <Filename Value="lpdisassembler_doeval.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit30>
       <Unit31>
-        <Filename Value="lpdisassembler_doeval.inc"/>
+        <Filename Value="lpinterpreter_invokerecords.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit31>
       <Unit32>
-        <Filename Value="lpinterpreter_invokerecords.inc"/>
+        <Filename Value="lpinterpreter_doinvoke.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit32>
       <Unit33>
-        <Filename Value="lpinterpreter_doinvoke.inc"/>
+        <Filename Value="lpinterpreter_invokeopcodes.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit33>
       <Unit34>
-        <Filename Value="lpinterpreter_invokeopcodes.inc"/>
+        <Filename Value="lpinterpreter_invokecase.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit34>
       <Unit35>
-        <Filename Value="lpinterpreter_invokecase.inc"/>
+        <Filename Value="lpdisassembler_doinvoke.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit35>
       <Unit36>
-        <Filename Value="lpdisassembler_doinvoke.inc"/>
+        <Filename Value="lpcodeemitter_invokeheader.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit36>
       <Unit37>
-        <Filename Value="lpcodeemitter_invokeheader.inc"/>
+        <Filename Value="lpcodeemitter_invokebody.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit37>
       <Unit38>
-        <Filename Value="lpcodeemitter_invokebody.inc"/>
+        <Filename Value="lpeval_wrappers_variant.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit38>
       <Unit39>
-        <Filename Value="lpeval_wrappers_variant.inc"/>
+        <Filename Value="lpeval_headers_variant.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit39>
       <Unit40>
-        <Filename Value="lpeval_headers_variant.inc"/>
+        <Filename Value="lpeval_import_variant.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit40>
       <Unit41>
-        <Filename Value="lpeval_import_variant.inc"/>
+        <Filename Value="lpeval_import_string.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit41>
       <Unit42>
-        <Filename Value="lpeval_import_string.inc"/>
+        <Filename Value="lpeval_wrappers_string.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit42>
       <Unit43>
-        <Filename Value="lpeval_wrappers_string.inc"/>
+        <Filename Value="lpeval_headers_string.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit43>
       <Unit44>
-        <Filename Value="lpeval_headers_string.inc"/>
+        <Filename Value="lpeval_import_datetime.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit44>
       <Unit45>
-        <Filename Value="lpeval_import_datetime.inc"/>
+        <Filename Value="lpeval_wrappers_datetime.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit45>
       <Unit46>
-        <Filename Value="lpeval_wrappers_datetime.inc"/>
+        <Filename Value="lpeval_headers_datetime.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit46>
       <Unit47>
-        <Filename Value="lpeval_headers_datetime.inc"/>
+        <Filename Value="lpeval_import_math.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit47>
       <Unit48>
-        <Filename Value="lpeval_import_math.inc"/>
+        <Filename Value="lpeval_wrappers_math.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit48>
       <Unit49>
-        <Filename Value="lpeval_wrappers_math.inc"/>
+        <Filename Value="lpeval_headers_math.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit49>
       <Unit50>
-        <Filename Value="lpeval_headers_math.inc"/>
+        <Filename Value="lpvartypes_array.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit50>
       <Unit51>
-        <Filename Value="lpvartypes_array.pas"/>
+        <Filename Value="lpvartypes_ord.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit51>
       <Unit52>
-        <Filename Value="lpvartypes_ord.pas"/>
+        <Filename Value="lpvartypes_record.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit52>
       <Unit53>
-        <Filename Value="lpvartypes_record.pas"/>
+        <Filename Value="lputils.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit53>
       <Unit54>
-        <Filename Value="lputils.pas"/>
+        <Filename Value="extensions\ffi\lpffi.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit54>
       <Unit55>
-        <Filename Value="extensions\ffi\lpffi.pas"/>
+        <Filename Value="extensions\ffi\ffi.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit55>
       <Unit56>
-        <Filename Value="extensions\ffi\ffi.pas"/>
+        <Filename Value="extensions\ffi\lpffiwrappers.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit56>
       <Unit57>
-        <Filename Value="extensions\ffi\lpffiwrappers.pas"/>
+        <Filename Value="lpmessages.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit57>
     </Units>

--- a/lape.lpr
+++ b/lape.lpr
@@ -9,7 +9,7 @@ uses
   Interfaces, // this includes the LCL widgetset
   Forms, Main,
 
-  lpparser, lpcompiler, lptypes, lpeval, lpinterpreter, lpexceptions,
+  lpparser, lpcompiler, lptypes, lpeval, lpinterpreter, lpmessages,
   lpvartypes, lpcodeemitter, lptree, lpdisassembler, lpvartypes_array, 
   lpvartypes_ord, lpvartypes_record, lputils, lpffi, ffi;
 

--- a/lpcodeemitter.pas
+++ b/lpcodeemitter.pas
@@ -166,7 +166,7 @@ type
 implementation
 
 uses
-  lpexceptions;
+  lpmessages;
 
 procedure TLapeCodeEmitterBase._Int8(v: Int8; Pos: PInt8);          begin Pos^ := v; end;
 procedure TLapeCodeEmitterBase._UInt8(v: UInt8; Pos: PUInt8);       begin Pos^ := v; end;

--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -1339,7 +1339,7 @@ begin
           if addToScope then
             FStackInfo.addSelfVar(Lape_SelfParam, TLapeType(Typ));
           Result.Free();
-          Result := TLapeType_MethodOfType.Create(Self, TLapeType(Typ), nil, nil, '', @Pos);
+          Result := TLapeType_MethodOfType.Create(Self, TLapeType(Typ), nil, nil, Name, @Pos);
         end
         else if (not (Typ is TLapeType_SystemUnit)) then
           LapeException(lpeTypeExpected, [Tokenizer]);
@@ -1563,7 +1563,7 @@ begin
     ResetStack := False;
 
   try
-    isNext([tk_kw_ConstRef, tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override, tk_kw_Static]);
+    isNext([tk_kw_Deprecated, tk_kw_ConstRef, tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override, tk_kw_Static]);
     OldDeclaration := getDeclarationNoWith(FuncName, FStackInfo.Owner);
     LocalDecl := (OldDeclaration <> nil) and hasDeclaration(OldDeclaration, FStackInfo.Owner, True, False);
 
@@ -1580,7 +1580,7 @@ begin
       TLapeType_MethodOfType(FuncHeader).SelfParam := lptConstRef;
       AddSelfVar(lptConstRef, TLapeType_MethodOfType(FuncHeader).ObjectType);
 
-      isNext([tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override]);
+      isNext([tk_kw_Deprecated, tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override]);
     end
     else if (Tokenizer.Tok = tk_kw_Static) then
     begin
@@ -1590,7 +1590,7 @@ begin
         RemoveSelfVar();
         FuncHeader := TLapeType_Method(addManagedType(TLapeType_Method.Create(FuncHeader)));
       end;
-      isNext([tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override]);
+      isNext([tk_kw_Deprecated, tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override]);
     end
     else if (not isExternal) and (not MethodOfObject(FuncHeader)) then
       FuncHeader := InheritMethodStack(FuncHeader, FStackInfo.Owner);
@@ -1638,7 +1638,7 @@ begin
           LapeException(lpString(E.Message), Tokenizer.DocPos);
         end;
 
-        isNext([tk_kw_External, tk_kw_Forward]);
+        isNext([tk_kw_External, tk_kw_Deprecated, tk_kw_Forward]);
       end
       else if (Tokenizer.Tok = tk_kw_Override) then
       begin
@@ -1761,6 +1761,14 @@ begin
         Result.FreeStackInfo := False;
         FreeAndNil(Result);
         Exit;
+      end;
+
+      if (Tokenizer.Tok = tk_kw_Deprecated) then
+      begin
+        TLapeType_Method(Result.Method.VarType).Deprecated := True;
+        Tokenizer.Expect(tk_typ_String);
+        TLapeType_Method(Result.Method.VarType).DeprecatedString := Copy(Tokenizer.TokString, 2, Tokenizer.TokLen - 2);
+        Tokenizer.Expect(tk_sym_SemiColon);
       end;
 
       if isExternal then
@@ -2319,6 +2327,7 @@ var
   _LastNode: (_None, _Var, _Op);
   InExpr: Integer;
   DoNext: Boolean;
+  GlobalVar: TLapeGlobalVar;
 
   procedure PopOpNode;
   var
@@ -2644,7 +2653,15 @@ begin
               TLapeTree_ResVar(Expr).ResVar.VarPos.StackVar.Used := duTrue
             else
             if (Expr is TLapeTree_GlobalVar) then
-              TLapeTree_GlobalVar(Expr).GlobalVar.Used := duTrue;
+            begin
+              GlobalVar := TLapeTree_GlobalVar(Expr).GlobalVar;
+              if (lcoHints in FOptions) and (GlobalVar.VarType is TLapeType_Method) then
+              begin
+                if (TLapeType_Method(GlobalVar.VarType).Deprecated) then
+                  Hint(lphDeprecatedMethod, [GlobalVar.Name, TLapeType_Method(GlobalVar.VarType).DeprecatedString], Tokenizer.DocPos);
+              end else
+                GlobalVar.Used := duTrue;
+            end;
 
             if (Expr is TLapeTree_Invoke) then
             begin

--- a/lpdisassembler.pas
+++ b/lpdisassembler.pas
@@ -28,7 +28,7 @@ procedure DisassembleCode(Code: PByte; PointerNames: TLapeDeclArray = nil); over
 implementation
 
 uses
-  lpexceptions, lpinterpreter, lpeval, lputils;
+  lpmessages, lpinterpreter, lpeval, lputils;
 
 procedure DisassembleCode(Code: PByte; PointerNames: TLapeDisassemblerPointerMap);
 var

--- a/lpeval.pas
+++ b/lpeval.pas
@@ -120,7 +120,7 @@ var
   LapeEvalRes: TLapeEvalRes;
   LapeEvalArr: TLapeEvalArr;
 
-  LapeDelayedFlags: lpString = '{$ASSERTIONS ON}{$BOOLEVAL ON}{$CONSTADDRESS ON}{$RANGECHECKS ON}{$AUTOINVOKE OFF}{$AUTOPROPERTIES OFF}{$LOOSESEMICOLON OFF}{$EXTENDEDSYNTAX OFF}' + LineEnding;
+  LapeDelayedFlags: lpString = '{$ASSERTIONS ON}{$BOOLEVAL ON}{$CONSTADDRESS ON}{$RANGECHECKS ON}{$AUTOINVOKE OFF}{$AUTOPROPERTIES OFF}{$LOOSESEMICOLON OFF}{$EXTENDEDSYNTAX OFF}{$HINTS OFF}' + LineEnding;
 
   _LapeToString_Enum: lpString =
     'function _EnumToString(s: ^const string; Index, Lo, Hi: SizeInt): string;'          + LineEnding +
@@ -397,7 +397,7 @@ uses
   Variants, Math,
   {$IFDEF Lape_NeedAnsiStringsUnit}AnsiStrings,{$ENDIF}
   {$IFDEF FPC}LCLIntf,{$ELSE}{$IFDEF MSWINDOWS}Windows,{$ENDIF}{$ENDIF}
-  lpexceptions, lpparser;
+  lpmessages, lpparser;
 
 {$RangeChecks Off}
 {$OverflowChecks Off}

--- a/lpexceptions.pas
+++ b/lpexceptions.pas
@@ -102,6 +102,8 @@ procedure LapeExceptionFmt(Msg: lpString; Args: array of const); overload;
 procedure LapeExceptionFmt(Msg: lpString; Args: array of const; DocPos: TDocPos); overload;
 procedure LapeExceptionFmt(Msg: lpString; Args: array of const; DocPos: array of TLapeBaseDeclClass); overload;
 
+function FormatLocation(Msg: lpString; DocPos: TDocPos): lpString;
+
 implementation
 
 {$IFDEF Lape_NeedAnsiStringsUnit}

--- a/lpexceptions.pas
+++ b/lpexceptions.pas
@@ -102,8 +102,6 @@ procedure LapeExceptionFmt(Msg: lpString; Args: array of const); overload;
 procedure LapeExceptionFmt(Msg: lpString; Args: array of const; DocPos: TDocPos); overload;
 procedure LapeExceptionFmt(Msg: lpString; Args: array of const; DocPos: array of TLapeBaseDeclClass); overload;
 
-function FormatLocation(Msg: lpString; DocPos: TDocPos): lpString;
-
 implementation
 
 {$IFDEF Lape_NeedAnsiStringsUnit}

--- a/lpinterpreter.pas
+++ b/lpinterpreter.pas
@@ -91,7 +91,7 @@ procedure RunCode(Code: PByte; InitialVarStack: TByteArray = nil; InitialJump: T
 implementation
 
 uses
-  lpexceptions;
+  lpmessages;
 
 {$OverFlowChecks Off}
 

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -5,7 +5,7 @@
 
   Lape exceptions.
 }
-unit lpexceptions;
+unit lpmessages;
 
 {$I lape.inc}
 
@@ -95,12 +95,18 @@ const
   lpeVariableOfTypeExpected = 'Expected variable of type "%s", got "%s"';
   lpeWrongNumberParams = 'Wrong number of parameters found, expected %d';
 
+  lphVariableNotUsed = 'Variable "%s" not used';
+  lphParameterNotUsed = 'Parameter "%s" not used';
+  lphResultNotSet = 'Result not set';
+
 procedure LapeException(Msg: lpString); overload;
 procedure LapeException(Msg: lpString; DocPos: TDocPos); overload;
 procedure LapeException(Msg: lpString; DocPos: array of TLapeBaseDeclClass); overload;
 procedure LapeExceptionFmt(Msg: lpString; Args: array of const); overload;
 procedure LapeExceptionFmt(Msg: lpString; Args: array of const; DocPos: TDocPos); overload;
 procedure LapeExceptionFmt(Msg: lpString; Args: array of const; DocPos: array of TLapeBaseDeclClass); overload;
+
+function FormatLocation(Msg: lpString; DocPos: TDocPos): lpString;
 
 implementation
 
@@ -127,7 +133,7 @@ begin
 end;
 {$ENDIF}
 
-function FormatLocation(Msg: lpString; DocPos: TDocPos): lpString; {inline;}
+function FormatLocation(Msg: lpString; DocPos: TDocPos): lpString;
 begin
   Result := Msg;
   if (DocPos.Line > 0) and (DocPos.Col > 0) then

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -99,6 +99,7 @@ const
   lphParameterNotUsed = 'Parameter "%s" not used';
   lphParamterNotSet = 'Parameter "%s" not set';
   lphResultNotSet = 'Result not set';
+  lphDeprecatedMethod = 'Method "%s" is deprecated "%s"';
 
 procedure LapeException(Msg: lpString); overload;
 procedure LapeException(Msg: lpString; DocPos: TDocPos); overload;

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -97,6 +97,7 @@ const
 
   lphVariableNotUsed = 'Variable "%s" not used';
   lphParameterNotUsed = 'Parameter "%s" not used';
+  lphParamterNotSet = 'Parameter "%s" not set';
   lphResultNotSet = 'Result not set';
 
 procedure LapeException(Msg: lpString); overload;

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -32,6 +32,7 @@ type
     tk_kw_Case,
     tk_kw_Const,
     tk_kw_ConstRef,
+    tk_kw_Deprecated,
     tk_kw_Do,
     tk_kw_DownTo,
     tk_kw_Else,
@@ -246,7 +247,7 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..48 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..49 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';          Token: tk_op_AND),
       (Keyword: 'DIV';          Token: tk_op_DIV),
       (Keyword: 'IN';           Token: tk_op_IN),
@@ -263,6 +264,7 @@ const
       (Keyword: 'CASE';         Token: tk_kw_Case),
       (Keyword: 'CONST';        Token: tk_kw_Const),
       (Keyword: 'CONSTREF';     Token: tk_kw_ConstRef),
+      (Keyword: 'DEPRECATED';   Token: tk_kw_Deprecated),
       (Keyword: 'DO';           Token: tk_kw_Do),
       (Keyword: 'DOWNTO';       Token: tk_kw_DownTo),
       (Keyword: 'ELSE';         Token: tk_kw_Else),

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -420,7 +420,7 @@ implementation
 uses
   typinfo,
   {$IFDEF Lape_NeedAnsiStringsUnit}AnsiStrings,{$ENDIF}
-  lpexceptions;
+  lpmessages;
 
 {$WARN WIDECHAR_REDUCED OFF}
 

--- a/lptree.pas
+++ b/lptree.pas
@@ -5158,22 +5158,24 @@ begin
     FCompiler.Emitter._JmpR(Offset - fo, fo, @_DocPos);
   end;
 
-  if (FCompiler.HasHintDefine) then
-    with FStackInfo do
-      for i := 0 to VarCount - 1 do
-      begin
-        if (Vars[i].Used <> duFalse) or (Vars[i].Name = '') or (Vars[i].Name[1] = '!') then
-          Continue;
+  with FStackInfo do
+    for i := 0 to VarCount - 1 do
+    begin
+      if (Vars[i].Used <> duFalse) or (Vars[i].Name = '') or (Vars[i].Name[1] = '!') then
+        Continue;
 
-        if (Vars[i] is TLapeParameterVar) then
-        begin
-          if (FStackInfo.Vars[i].Name = 'Result') then
-            FCompiler.Hint(lphResultNotSet, [], Vars[i]._DocPos)
-          else
-            FCompiler.Hint(lphParameterNotUsed, [Vars[i].Name], Vars[i]._DocPos);
-        end else
-          FCompiler.Hint(lphVariableNotUsed, [Vars[i].Name], Vars[i]._DocPos);
-      end;
+      if (Vars[i] is TLapeParameterVar) then
+      begin
+        if (TLapeParameterVar(Vars[i]).ParType = lptOut) then
+          FCompiler.Hint(lphParamterNotSet, [Vars[i].Name], Vars[i]._DocPos)
+        else
+        if (Vars[i].Name = 'Result') then
+          FCompiler.Hint(lphResultNotSet, [], Vars[i]._DocPos)
+        else
+          FCompiler.Hint(lphParameterNotUsed, [Vars[i].Name], Vars[i]._DocPos);
+      end else
+        FCompiler.Hint(lphVariableNotUsed, [Vars[i].Name], Vars[i]._DocPos);
+    end;
 end;
 
 function TLapeTree_method.canExit: Boolean;

--- a/lptree.pas
+++ b/lptree.pas
@@ -2333,6 +2333,10 @@ begin
   begin
     IdentVar := IdentExpr.Compile(Offset);
 
+    if (IdentVar.VarType is TLapeType_MethodOfType) and (TLapeType_MethodOfType(IdentVar.VarType).Deprecated) then
+      with TLapeType_MethodOfType(IdentVar.VarType) do
+        FCompiler.Hint(lphDeprecatedMethod, [Name, DeprecatedString], IdentExpr.DocPos);
+
     if (not IdentVar.HasType()) or
        (not (IdentVar.VarType is TLapeType_Method))
     then

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -2169,7 +2169,7 @@ constructor TLapeDeclaration.Create(AName: lpString = ''; ADocPos: PDocPos = nil
 begin
   inherited Create();
   Name := AName;
-  Used := duFalse;
+  Used := duIgnore;
   if (ADocPos <> nil) then
     _DocPos := ADocPos^
   else

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -465,6 +465,8 @@ type
     property Sorted: Boolean read getSorted write setSorted;
   end;
 
+  EDeclarationUsed = (duFalse, duTrue, duIgnore);
+
   TLapeDeclaration = class(TLapeBaseDeclClass)
   protected
     FList: TLapeDeclarationList;
@@ -475,7 +477,7 @@ type
     procedure setName(AName: lpString); virtual;
   public
     _DocPos: TDocPos;
-    Used: Boolean;
+    Used: EDeclarationUsed;
     constructor Create(AName: lpString = ''; ADocPos: PDocPos = nil; AList: TLapeDeclarationList = nil); reintroduce; virtual;
     destructor Destroy; override;
 
@@ -667,7 +669,7 @@ implementation
 uses
   typinfo, variants,
   {$IFDEF Lape_NeedAnsiStringsUnit}AnsiStrings,{$ENDIF}
-  lpexceptions;
+  lpmessages;
 
 function LapeCase(const Str: lpString): lpString;
 begin
@@ -2167,7 +2169,7 @@ constructor TLapeDeclaration.Create(AName: lpString = ''; ADocPos: PDocPos = nil
 begin
   inherited Create();
   Name := AName;
-  Used := False;
+  Used := duFalse;
   if (ADocPos <> nil) then
     _DocPos := ADocPos^
   else

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -539,7 +539,7 @@ type
     function addDeclaration(Decl: TLapeDeclaration): Integer; override;
     function addVar(StackVar: TLapeStackVar): TLapeStackVar; overload; virtual;
     function addVar(VarType: TLapeType; Name: lpString = ''): TLapeStackVar; overload; virtual;
-    function addVar(ParType: ELapeParameterType; VarType: TLapeType; Name: lpString = ''; IgnoreUsed: Boolean = False): TLapeStackVar; overload; virtual;
+    function addVar(ParType: ELapeParameterType; VarType: TLapeType; Name: lpString = ''): TLapeStackVar; overload; virtual;
     function addSelfVar(ParType: ELapeParameterType; VarType: TLapeType): TLapeStackVar; overload; virtual;
 
     function inheritVar(StackVar: TLapeStackVar): TLapeStackVar; virtual;
@@ -615,7 +615,6 @@ type
     FOptions_PackRecords: UInt8;
 
     FOnHint: TLapeHint;
-    FHasHintDefine: Boolean;
 
     procedure Reset; virtual;
     procedure setEmitter(AEmitter: TLapeCodeEmitter); virtual;
@@ -677,7 +676,6 @@ type
     function hasDeclaration(ADecl: TLapeDeclaration; LocalOnly: Boolean = False; CheckWith: Boolean = True): Boolean; overload; virtual;
 
     procedure Hint(Msg: lpString; Args: array of const; ADocPos: TDocPos);
-    property HasHintDefine: Boolean read FHasHintDefine;
 
     property StackInfo: TLapeStackInfo read FStackInfo;
     property BaseTypes: TLapeBaseTypes read FBaseTypes;
@@ -3533,21 +3531,17 @@ begin
     Result := addVar(TLapeStackVar.Create(VarType, nil, Name));
 end;
 
-function TLapeStackInfo.addVar(ParType: ELapeParameterType; VarType: TLapeType; Name: lpString; IgnoreUsed: Boolean): TLapeStackVar;
+function TLapeStackInfo.addVar(ParType: ELapeParameterType; VarType: TLapeType; Name: lpString): TLapeStackVar;
 begin
   if (VarType = nil) then
     Result := addVar(TLapeParameterVar.Create(ParType, VarType, nil, Name))
   else
     Result := addVar(TLapeParameterVar.Create(ParType, VarType, nil, Name, @VarType._DocPos));
-
-  if (IgnoreUsed) then
-    Result.Used := duIgnore;
 end;
 
 function TLapeStackInfo.addSelfVar(ParType: ELapeParameterType; VarType: TLapeType): TLapeStackVar;
 begin
   Result := addVar(ParType, VarType, 'Self');
-  Result.Used := duIgnore;
 end;
 
 function TLapeStackInfo.inheritVar(StackVar: TLapeStackVar): TLapeStackVar;
@@ -4566,10 +4560,8 @@ end;
 
 procedure TLapeCompilerBase.Hint(Msg: lpString; Args: array of const; ADocPos: TDocPos);
 begin
-  Assert(lcoHints in Options);
-  Assert({$IFDEF FPC}@{$ENDIF}FOnHint <> nil);
-
-  FOnHint(Self, FormatLocation(Format(Msg, Args), ADocPos));
+  if ({$IFDEF FPC}@{$ENDIF}FOnHint <> nil) then
+    FOnHint(Self, FormatLocation(Format(Msg, Args), ADocPos));
 end;
 
 initialization

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -595,6 +595,8 @@ type
     function _Eval(AProc: TLapeEvalProc; Dest, Left, Right: TResVar; Pos: PDocPos = nil): Integer; overload; virtual;
   end;
 
+  TLapeCompileHint = procedure(Sender: TLapeCompilerBase; Hint: String) of object;
+
   TLapeCompilerBase = class(TLapeBaseDeclClass)
   protected
     FEmitter: TLapeCodeEmitter;
@@ -610,6 +612,8 @@ type
     FOptions: ECompilerOptionsSet;
     FOptions_PackRecords: UInt8;
 
+    FOnCompileHint: TLapeCompileHint;
+
     procedure Reset; virtual;
     procedure setEmitter(AEmitter: TLapeCodeEmitter); virtual;
   public
@@ -618,6 +622,8 @@ type
     constructor Create(AEmitter: TLapeCodeEmitter = nil; ManageEmitter: Boolean = True); reintroduce; virtual;
     destructor Destroy; override;
     procedure Clear; virtual;
+
+    procedure HandleHint(Msg: lpString; ADocPos: TDocPos);
 
     procedure VarToDefault(AVar: TResVar; var Offset: Integer; Pos: PDocPos = nil); overload; virtual;
     procedure VarToDefault(AVar: TResVar; Pos: PDocPos = nil); overload; virtual;
@@ -679,6 +685,8 @@ type
     property Emitter: TLapeCodeEmitter read FEmitter write setEmitter;
     property Options: ECompilerOptionsSet read FOptions write FBaseOptions default Lape_OptionsDef;
     property Options_PackRecords: UInt8 read FOptions_PackRecords write FBaseOptions_PackRecords default Lape_PackRecordsDef;
+
+    property OnCompileHint: TLapeCompileHint read FOnCompileHint write FOnCompileHint;
   end;
 
 function ResolveCompoundOp(op:EOperator; typ:TLapeType): EOperator; {$IFDEF Lape_Inline}inline;{$ENDIF}
@@ -1878,9 +1886,11 @@ function TLapeType.Eval(Op: EOperator; var Dest: TResVar; Left, Right: TResVar; 
 
 var
   EvalProc: TLapeEvalProc;
+  LeftHi, RightHi: UInt64;
 begin
   Result := NullResVar;
   Assert(FCompiler <> nil);
+
 
   if (Left.VarPos.MemPos = NullResVar.VarPos.MemPos) then
   begin
@@ -1940,6 +1950,26 @@ begin
         LapeExceptionFmt(lpeIncompatibleOperator1, [LapeOperatorToString(op), AsString])
       else
         LapeExceptionFmt(lpeIncompatibleOperator, [LapeOperatorToString(op)]);
+
+    if ({$IFNDEF FPC}@{$ENDIF}FCompiler.OnCompileHint <> nil) and (Pos <> nil) and (op = op_Assign) then
+    begin
+      if (Left.HasType()) and (Left.VarType.BaseType in LapeIntegerTypes) and
+         (Right.HasType()) and (Right.VarType.BaseType in LapeIntegerTypes) then
+        begin
+          LeftHi := 0;
+          RightHi := 0;
+
+          Move(LapeTypeHigh[Left.VarType.BaseType]^, LeftHi, Left.VarType.Size);
+
+          if (Right.VarPos.GlobalVar <> nil) and (Right.VarPos.GlobalVar.Ptr <> nil) and (Right.VarPos.GlobalVar.AsInteger <> 0) then
+            Move(Right.VarPos.GlobalVar.Ptr^, RightHi, Right.VarType.Size) // x := 15;
+          else
+            Move(LapeTypeHigh[Right.VarType.BaseType]^, RightHi, Right.VarType.Size); // x := Something
+
+          if (RightHi > LeftHi) then
+            FCompiler.HandleHint(Format('Possible overflow (%s, %s)', [Left.VarType.AsString, Right.VarType.AsString]), Pos^);
+        end;
+    end;
 
     FCompiler.getDestVar(Dest, Result, op);
 
@@ -3906,6 +3936,8 @@ begin
   FBaseOptions := Lape_OptionsDef;
   FBaseOptions_PackRecords := Lape_PackRecordsDef;
 
+  FOnCompileHint := nil;
+
   FreeEmitter := ManageEmitter;
   if (AEmitter = nil) then
     AEmitter := TLapeCodeEmitter.Create();
@@ -3941,6 +3973,12 @@ begin
   FManagedDeclarations.Clear();
   FCachedDeclarations.Clear();
   Reset();
+end;
+
+procedure TLapeCompilerBase.HandleHint(Msg: lpString; ADocPos: TDocPos);
+begin
+  if ({$IFDEF FPC}@{$ENDIF}FOnCompileHint <> nil) then
+    FOnCompileHint(Self, FormatLocation(Msg, ADocPos));
 end;
 
 procedure TLapeCompilerBase.VarToDefault(AVar: TResVar; var Offset: Integer; Pos: PDocPos = nil);

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -364,6 +364,8 @@ type
     ImplicitParams: Integer;
     Res: TLapeType;
     IsOperator: Boolean;
+    Deprecated: Boolean;
+    DeprecatedString: String;
 
     constructor Create(ACompiler: TLapeCompilerBase; AParams: TLapeParameterList; ARes: TLapeType = nil; AName: lpString = ''; ADocPos: PDocPos = nil); reintroduce; overload; virtual;
     constructor Create(ACompiler: TLapeCompilerBase; AParams: array of TLapeType; AParTypes: array of ELapeParameterType; AParDefaults: array of TLapeGlobalVar; ARes: TLapeType = nil; AName: lpString = ''; ADocPos: PDocPos = nil); reintroduce; overload; virtual;
@@ -2467,6 +2469,8 @@ begin
     AParams := TLapeParameterList.Create(NullParameter, dupAccept, False);
   FParams := AParams;
   Res := ARes;
+  Deprecated := False;
+  DeprecatedString := '';
 end;
 
 constructor TLapeType_Method.Create(ACompiler: TLapeCompilerBase; AParams: array of TLapeType; AParTypes: array of ELapeParameterType; AParDefaults: array of TLapeGlobalVar; ARes: TLapeType = nil; AName: lpString = ''; ADocPos: PDocPos = nil);

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -107,7 +107,7 @@ type
 implementation
 
 uses
-  lpparser, lpeval, lpexceptions;
+  lpparser, lpeval, lpmessages;
 
 function TLapeType_DynArray.getAsString: lpString;
 begin

--- a/lpvartypes_ord.pas
+++ b/lpvartypes_ord.pas
@@ -189,7 +189,7 @@ implementation
 uses
   Variants,
   {$IFDEF Lape_NeedAnsiStringsUnit}AnsiStrings,{$ENDIF}
-  lpparser, lpeval, lpexceptions;
+  lpparser, lpeval, lpmessages;
 
 function TLapeType_Integer{$IFNDEF FPC}<_Type>{$ENDIF}.NewGlobalVar(Val: _Type; AName: lpString = ''; ADocPos: PDocPos = nil): TLapeGlobalVar;
 begin

--- a/lpvartypes_record.pas
+++ b/lpvartypes_record.pas
@@ -67,7 +67,7 @@ implementation
 
 uses
   Math,
-  lpvartypes_array, lpparser, lpeval, lpexceptions;
+  lpvartypes_array, lpparser, lpeval, lpmessages;
 
 function TLapeType_Record.getAsString: lpString;
 var

--- a/main.lfm
+++ b/main.lfm
@@ -6,7 +6,7 @@ object Form1: TForm1
   Caption = 'Form1'
   ClientHeight = 692
   ClientWidth = 497
-  LCLVersion = '1.4.0.1'
+  LCLVersion = '1.6.0.4'
   inline e: TSynEdit
     Left = 0
     Height = 531
@@ -535,6 +535,8 @@ object Form1: TForm1
         Command = emcStartDragMove
       end>
     Lines.Strings = (
+      '{$HINTS ON}'
+      ''
       'type'
       '  TPoint = record'
       '    x, y: Integer;'
@@ -567,7 +569,6 @@ object Form1: TForm1
       'end;'
     )
     VisibleSpecialChars = [vscSpace, vscTabAtLast]
-    SelectedColor.FrameEdges = sfeAround
     SelectedColor.BackPriority = 50
     SelectedColor.ForePriority = 50
     SelectedColor.FramePriority = 50
@@ -575,23 +576,17 @@ object Form1: TForm1
     SelectedColor.ItalicPriority = 50
     SelectedColor.UnderlinePriority = 50
     SelectedColor.StrikeOutPriority = 50
-    IncrementColor.FrameEdges = sfeAround
-    HighlightAllColor.FrameEdges = sfeAround
     BracketHighlightStyle = sbhsBoth
     BracketMatchColor.Background = clNone
     BracketMatchColor.Foreground = clNone
-    BracketMatchColor.FrameEdges = sfeAround
     BracketMatchColor.Style = [fsBold]
     FoldedCodeColor.Background = clNone
     FoldedCodeColor.Foreground = clGray
     FoldedCodeColor.FrameColor = clGray
-    FoldedCodeColor.FrameEdges = sfeAround
     MouseLinkColor.Background = clNone
     MouseLinkColor.Foreground = clBlue
-    MouseLinkColor.FrameEdges = sfeAround
     LineHighlightColor.Background = clNone
     LineHighlightColor.Foreground = clNone
-    LineHighlightColor.FrameEdges = sfeAround
     inline SynLeftGutterPartList1: TSynGutterPartList
       object SynGutterMarks1: TSynGutterMarks
         Width = 24
@@ -602,7 +597,6 @@ object Form1: TForm1
         MouseActions = <>
         MarkupInfo.Background = clBtnFace
         MarkupInfo.Foreground = clNone
-        MarkupInfo.FrameEdges = sfeAround
         DigitCount = 2
         ShowOnlyLineNumbersMultiplesOf = 1
         ZeroStart = False
@@ -619,7 +613,6 @@ object Form1: TForm1
         MouseActions = <>
         MarkupInfo.Background = clWhite
         MarkupInfo.Foreground = clGray
-        MarkupInfo.FrameEdges = sfeAround
       end
       object SynGutterCodeFolding1: TSynGutterCodeFolding
         MouseActions = <        
@@ -650,7 +643,6 @@ object Form1: TForm1
           end>
         MarkupInfo.Background = clNone
         MarkupInfo.Foreground = clGray
-        MarkupInfo.FrameEdges = sfeAround
         MouseActionsExpanded = <        
           item
             ClickCount = ccAny
@@ -754,24 +746,13 @@ object Form1: TForm1
   end
   object PasSyn: TSynPasSyn
     Enabled = False
-    AsmAttri.FrameEdges = sfeAround
     CommentAttri.Foreground = clGreen
-    CommentAttri.FrameEdges = sfeAround
     CommentAttri.Style = []
-    IDEDirectiveAttri.FrameEdges = sfeAround
-    IdentifierAttri.FrameEdges = sfeAround
-    KeyAttri.FrameEdges = sfeAround
     NumberAttri.Foreground = clNavy
-    NumberAttri.FrameEdges = sfeAround
-    SpaceAttri.FrameEdges = sfeAround
     StringAttri.Foreground = clTeal
-    StringAttri.FrameEdges = sfeAround
     SymbolAttri.Foreground = clMaroon
-    SymbolAttri.FrameEdges = sfeAround
-    CaseLabelAttri.FrameEdges = sfeAround
     CaseLabelAttri.Style = [fsItalic]
     DirectiveAttri.Foreground = clOlive
-    DirectiveAttri.FrameEdges = sfeAround
     CompilerMode = pcmDelphi
     NestedComments = False
     left = 432

--- a/main.pas
+++ b/main.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, FileUtil, Forms, Controls, Graphics, Dialogs,
-  StdCtrls, ExtCtrls, SynEdit, SynHighlighterPas, lptypes;
+  StdCtrls, ExtCtrls, SynEdit, SynHighlighterPas, lptypes, lpvartypes;
 
 type
 
@@ -29,9 +29,7 @@ type
     procedure btnEvalArrClick(Sender: TObject);
     procedure btnRunClick(Sender: TObject);
   private
-    { private declarations }
-  public
-    { public declarations }
+    procedure WriteHint(Sender: TLapeCompilerBase; Msg: lpString);
   end; 
 
 var
@@ -40,7 +38,7 @@ var
 implementation
 
 uses
-  lpparser, lpcompiler, lputils, lpvartypes, lpeval, lpinterpreter, lpdisassembler, {_lpgenerateevalfunctions,}
+  lpparser, lpcompiler, lputils, lpeval, lpinterpreter, lpdisassembler, {_lpgenerateevalfunctions,}
   LCLIntf, typinfo, ffi, lpffi, lpffiwrappers;
 
 {$R *.lfm}
@@ -93,7 +91,7 @@ procedure Compile(Run, Disassemble: Boolean);
   end;
 
 var
-  t: Cardinal;
+  t: UInt64;
   Parser: TLapeTokenizerBase;
   Compiler: TLapeCompiler;
 begin
@@ -103,6 +101,7 @@ begin
     try
       Parser := TLapeTokenizerString.Create({$IF DEFINED(Lape_Unicode)}UTF8Decode(e.Lines.Text){$ELSE}e.Lines.Text{$IFEND});
       Compiler := TLapeCompiler.Create(Parser);
+      Compiler.OnHint := @WriteHint;
 
       InitializeFFI(Compiler);
       InitializePascalScriptBasics(Compiler, [psiTypeAlias]);
@@ -132,10 +131,10 @@ begin
 
         if Run then
         begin
-          t := getTickCount;
+          t := GetTickCount64();
           m.Append(LineEnding);
           RunCode(Compiler.Emitter.Code);
-          m.Append('Running Time: ' + IntToStr(getTickCount - t) + 'ms.');
+          m.Append('Running Time: ' + IntToStr(GetTickCount64() - t) + 'ms.');
         end;
       except
         on E: Exception do
@@ -152,6 +151,11 @@ end;
 procedure TForm1.btnRunClick(Sender: TObject);
 begin
   Compile(True, False);
+end;
+
+procedure TForm1.WriteHint(Sender: TLapeCompilerBase; Msg: lpString);
+begin
+  m.Append(Msg);
 end;
 
 procedure TForm1.btnDisassembleClick(Sender: TObject);

--- a/main.pas
+++ b/main.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, FileUtil, Forms, Controls, Graphics, Dialogs,
-  StdCtrls, ExtCtrls, SynEdit, SynHighlighterPas, lptypes;
+  StdCtrls, ExtCtrls, SynEdit, SynHighlighterPas, lptypes, lpcompiler, lpvartypes;
 
 type
 
@@ -23,11 +23,13 @@ type
     pnlTop: TPanel;
     Splitter1: TSplitter;
     PasSyn: TSynPasSyn;
+
     procedure btnDisassembleClick(Sender: TObject);
     procedure btnMemLeaksClick(Sender: TObject);
     procedure btnEvalResClick(Sender: TObject);
     procedure btnEvalArrClick(Sender: TObject);
     procedure btnRunClick(Sender: TObject);
+    procedure WriteCompileHint(Sender: TLapeCompilerBase; Msg: String);
   private
     { private declarations }
   public
@@ -40,7 +42,7 @@ var
 implementation
 
 uses
-  lpparser, lpcompiler, lputils, lpvartypes, lpeval, lpinterpreter, lpdisassembler, {_lpgenerateevalfunctions,}
+  lpparser, lputils, lpeval, lpinterpreter, lpdisassembler, {_lpgenerateevalfunctions,}
   LCLIntf, typinfo, ffi, lpffi, lpffiwrappers;
 
 {$R *.lfm}
@@ -99,10 +101,12 @@ var
 begin
   Parser := nil;
   Compiler := nil;
+
   with Form1 do
     try
       Parser := TLapeTokenizerString.Create({$IF DEFINED(Lape_Unicode)}UTF8Decode(e.Lines.Text){$ELSE}e.Lines.Text{$IFEND});
       Compiler := TLapeCompiler.Create(Parser);
+      Compiler.OnCompileHint := @WriteCompileHint;
 
       InitializeFFI(Compiler);
       InitializePascalScriptBasics(Compiler, [psiTypeAlias]);
@@ -111,6 +115,9 @@ begin
       Compiler.addGlobalMethod('procedure _write(s: string); override;', @MyWrite, Form1);
       Compiler.addGlobalMethod('procedure _writeln; override;', @MyWriteLn, Form1);
       Compiler.addGlobalFunc('function MyStupidProc: array of integer', @MyStupidProc);
+
+      m.Clear;
+      WriteLn(LineEnding);
 
       try
         t := getTickCount;
@@ -152,6 +159,11 @@ end;
 procedure TForm1.btnRunClick(Sender: TObject);
 begin
   Compile(True, False);
+end;
+
+procedure TForm1.WriteCompileHint(Sender: TLapeCompilerBase; Msg: String);
+begin
+  m.Append(Msg);
 end;
 
 procedure TForm1.btnDisassembleClick(Sender: TObject);

--- a/package/lape.lpk
+++ b/package/lape.lpk
@@ -158,96 +158,96 @@ https://github.com/nielsAD/lape"/>
         <Type Value="Include"/>
       </Item30>
       <Item31>
-        <Filename Value="..\lpexceptions.pas"/>
-        <UnitName Value="lpexceptions"/>
-      </Item31>
-      <Item32>
         <Filename Value="..\lpinterpreter.pas"/>
         <UnitName Value="lpinterpreter"/>
+      </Item31>
+      <Item32>
+        <Filename Value="..\lpinterpreter_doeval.inc"/>
+        <Type Value="Include"/>
       </Item32>
       <Item33>
-        <Filename Value="..\lpinterpreter_doeval.inc"/>
+        <Filename Value="..\lpinterpreter_doinvoke.inc"/>
         <Type Value="Include"/>
       </Item33>
       <Item34>
-        <Filename Value="..\lpinterpreter_doinvoke.inc"/>
+        <Filename Value="..\lpinterpreter_dojump.inc"/>
         <Type Value="Include"/>
       </Item34>
       <Item35>
-        <Filename Value="..\lpinterpreter_dojump.inc"/>
+        <Filename Value="..\lpinterpreter_evalcase.inc"/>
         <Type Value="Include"/>
       </Item35>
       <Item36>
-        <Filename Value="..\lpinterpreter_evalcase.inc"/>
+        <Filename Value="..\lpinterpreter_evalopcodes.inc"/>
         <Type Value="Include"/>
       </Item36>
       <Item37>
-        <Filename Value="..\lpinterpreter_evalopcodes.inc"/>
+        <Filename Value="..\lpinterpreter_evalrecords.inc"/>
         <Type Value="Include"/>
       </Item37>
       <Item38>
-        <Filename Value="..\lpinterpreter_evalrecords.inc"/>
+        <Filename Value="..\lpinterpreter_invokecase.inc"/>
         <Type Value="Include"/>
       </Item38>
       <Item39>
-        <Filename Value="..\lpinterpreter_invokecase.inc"/>
+        <Filename Value="..\lpinterpreter_invokeopcodes.inc"/>
         <Type Value="Include"/>
       </Item39>
       <Item40>
-        <Filename Value="..\lpinterpreter_invokeopcodes.inc"/>
+        <Filename Value="..\lpinterpreter_invokerecords.inc"/>
         <Type Value="Include"/>
       </Item40>
       <Item41>
-        <Filename Value="..\lpinterpreter_invokerecords.inc"/>
+        <Filename Value="..\lpinterpreter_jumpcase.inc"/>
         <Type Value="Include"/>
       </Item41>
       <Item42>
-        <Filename Value="..\lpinterpreter_jumpcase.inc"/>
+        <Filename Value="..\lpinterpreter_jumpopcodes.inc"/>
         <Type Value="Include"/>
       </Item42>
       <Item43>
-        <Filename Value="..\lpinterpreter_jumpopcodes.inc"/>
+        <Filename Value="..\lpinterpreter_jumprecords.inc"/>
         <Type Value="Include"/>
       </Item43>
       <Item44>
-        <Filename Value="..\lpinterpreter_jumprecords.inc"/>
+        <Filename Value="..\lpinterpreter_opcodecase.inc"/>
         <Type Value="Include"/>
       </Item44>
       <Item45>
-        <Filename Value="..\lpinterpreter_opcodecase.inc"/>
-        <Type Value="Include"/>
-      </Item45>
-      <Item46>
         <Filename Value="..\lpparser.pas"/>
         <UnitName Value="lpparser"/>
-      </Item46>
-      <Item47>
+      </Item45>
+      <Item46>
         <Filename Value="..\lptree.pas"/>
         <UnitName Value="lptree"/>
-      </Item47>
-      <Item48>
+      </Item46>
+      <Item47>
         <Filename Value="..\lptypes.pas"/>
         <UnitName Value="lptypes"/>
-      </Item48>
-      <Item49>
+      </Item47>
+      <Item48>
         <Filename Value="..\lpvartypes.pas"/>
         <UnitName Value="lpvartypes"/>
-      </Item49>
-      <Item50>
+      </Item48>
+      <Item49>
         <Filename Value="..\lpvartypes_array.pas"/>
         <UnitName Value="lpvartypes_array"/>
-      </Item50>
-      <Item51>
+      </Item49>
+      <Item50>
         <Filename Value="..\lpvartypes_ord.pas"/>
         <UnitName Value="lpvartypes_ord"/>
-      </Item51>
-      <Item52>
+      </Item50>
+      <Item51>
         <Filename Value="..\lpvartypes_record.pas"/>
         <UnitName Value="lpvartypes_record"/>
-      </Item52>
-      <Item53>
+      </Item51>
+      <Item52>
         <Filename Value="..\lputils.pas"/>
         <UnitName Value="lputils"/>
+      </Item52>
+      <Item53>
+        <Filename Value="..\lpmessages.pas"/>
+        <UnitName Value="lpmessages"/>
       </Item53>
     </Files>
     <RequiredPkgs Count="1">

--- a/package/lape.pas
+++ b/package/lape.pas
@@ -7,9 +7,9 @@ unit lape;
 interface
 
 uses
-  lpcodeemitter, lpcompiler, lpdisassembler, lpeval, lpexceptions, 
-  lpinterpreter, lpparser, lptree, lptypes, lpvartypes, lpvartypes_array, 
-  lpvartypes_ord, lpvartypes_record, lputils;
+  lpcodeemitter, lpcompiler, lpdisassembler, lpeval, lpinterpreter, lpparser, 
+  lptree, lptypes, lpvartypes, lpvartypes_array, lpvartypes_ord, 
+  lpvartypes_record, lputils, lpmessages;
 
 implementation
 

--- a/tests/RunTests/lptest.pas
+++ b/tests/RunTests/lptest.pas
@@ -28,7 +28,7 @@ implementation
 uses
   {$IFDEF FPC}LCLIntf,{$ELSE}{$IFDEF MSWINDOWS}Windows,{$ENDIF}{$ENDIF} strutils,
   {$IFDEF Lape_NeedAnsiStringsUnit}AnsiStrings,{$ENDIF}
-  lpcompiler, lpparser, lpexceptions, lpinterpreter, lputils;
+  lpcompiler, lpparser, lpmessages, lpinterpreter, lputils;
 
 {$IFNDEF FPC} //Internal error workaround
 {$IF NOT DECLARED(GetTickCount)}


### PR DESCRIPTION
Added deprecated hints the same way Lazarus does.

```
function Foo: Boolean; deprecated 'This method has been replaced with function Bar'; 
```
On method usage:
>Method "Foo" is deprecated "This method has been replaced with function Bar" at line 8, column 3