### PR TITLE
Fix addGlobalMethod overloading/overriding

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -1702,7 +1702,10 @@ begin
         end;
 
         if (MethodOfObject(TLapeGlobalVar(OldDeclaration).VarType) <> MethodOfObject(Result.Method.VarType)) then
-          LapeException(lpeNoForwardMatch, Tokenizer.DocPos);
+        begin
+          if (not MethodOfObject(TLapeGlobalVar(OldDeclaration).VarType) and TLapeType_MethodOfObject(TLapeGlobalVar(OldDeclaration).VarType).HiddenSelf) then
+            LapeException(lpeNoForwardMatch, Tokenizer.DocPos);
+        end;
 
         if LocalDecl then
         begin
@@ -3932,6 +3935,7 @@ begin
 
   Result := TLapeType_MethodOfObject(addManagedType(TLapeType_MethodOfObject.Create(AFunc.VarType as TLapeType_Method))).NewGlobalVar(Value, AFunc.Name);
   Result.setReadWrite(False, False);
+  TLapeType_MethodOfObject(Result.VarType).HiddenSelf := not (AFunc.VarType is TLapeType_MethodOfObject);
 
   if (AFunc.DeclarationList <> nil) then
     Result.DeclarationList := AFunc.DeclarationList


### PR DESCRIPTION
overloading and overriding methods added with addGlobalMethod script sided were broken. I added a FHiddenSelf variable which is set in addGlobalMethod and referenced in overloading/overriding methods to allow compilation. 

The following now executes:

```pascal
Compiler.addGlobalMethod('procedure Testing;', @Testing, Data);
```

```pascal
procedure testing; override;
begin
  writeLn('2');
  inherited();
end;

procedure testing; override;
begin
  writeLn('1');
  inherited();
end;

procedure testing(s: String); overload;
begin
  testing();
end;

procedure testing(i: Int32); overload;
begin
  testing(IntToStr(i));
end;

begin
  testing(123);
end.
```