### PR TITLE
Current directory macro & basic filename parsing methods

### DIFF
--- a/lape.lpi
+++ b/lape.lpi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="9"/>
+    <Version Value="10"/>
     <PathDelim Value="\"/>
     <General>
       <SessionStorage Value="InProjectDir"/>
@@ -11,9 +11,6 @@
     <i18n>
       <EnableI18N LFM="False"/>
     </i18n>
-    <VersionInfo>
-      <StringTable ProductVersion=""/>
-    </VersionInfo>
     <BuildModes Count="4">
       <Item1 Name="Debug" Default="True"/>
       <Item2 Name="Deploy">
@@ -162,7 +159,7 @@
         <PackageName Value="LCL"/>
       </Item3>
     </RequiredPackages>
-    <Units Count="58">
+    <Units Count="61">
       <Unit0>
         <Filename Value="lape.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -320,15 +317,15 @@
         <IsPartOfProject Value="True"/>
       </Unit37>
       <Unit38>
-        <Filename Value="lpeval_wrappers_variant.inc"/>
+        <Filename Value="lpeval_wrappers_file.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit38>
       <Unit39>
-        <Filename Value="lpeval_headers_variant.inc"/>
+        <Filename Value="lpeval_headers_file.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit39>
       <Unit40>
-        <Filename Value="lpeval_import_variant.inc"/>
+        <Filename Value="lpeval_import_file.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit40>
       <Unit41>
@@ -399,6 +396,18 @@
         <Filename Value="lpmessages.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit57>
+      <Unit58>
+        <Filename Value="lpeval_headers_variant.inc"/>
+        <IsPartOfProject Value="True"/>
+      </Unit58>
+      <Unit59>
+        <Filename Value="lpeval_import_variant.inc"/>
+        <IsPartOfProject Value="True"/>
+      </Unit59>
+      <Unit60>
+        <Filename Value="lpeval_wrappers_variant.inc"/>
+        <IsPartOfProject Value="True"/>
+      </Unit60>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -749,6 +749,7 @@ begin
   {$I lpeval_import_string.inc}
   {$I lpeval_import_datetime.inc}
   {$I lpeval_import_variant.inc}
+  {$I lpeval_import_file.inc}
 
   addDelayedCode(
     LapeDelayedFlags +
@@ -1017,6 +1018,9 @@ begin
   begin
     if (LowerCase(Argument) = 'current_file') and (Sender is TLapeTokenizerFile) then
       IncludeFile := #39 + TLapeTokenizerFile(Sender).FileName + #39
+    else
+    if (LowerCase(Argument) = 'current_directory') and (Sender is TLapeTokenizerFile) then
+      IncludeFile := #39 + ExtractFileDir(TLapeTokenizerFile(Sender).FileName) + #39
     else
     begin
       IncludeFile := FDefines.Values[string(Trim(Argument))];

--- a/lpeval.pas
+++ b/lpeval.pas
@@ -96,6 +96,7 @@ procedure _LapeToString_Pointer(const Params: PParamArray; const Result: Pointer
 {$I lpeval_headers_string.inc}
 {$I lpeval_headers_datetime.inc}
 {$I lpeval_headers_variant.inc}
+{$I lpeval_headers_file.inc}
 
 procedure ClearToStrArr(var Arr: TLapeToStrArr);
 procedure LoadToStrArr(var Arr: TLapeToStrArr);
@@ -747,6 +748,7 @@ type
 {$I lpeval_wrappers_string.inc}
 {$I lpeval_wrappers_datetime.inc}
 {$I lpeval_wrappers_variant.inc}
+{$I lpeval_wrappers_file.inc}
 
 procedure ClearToStrArr(var Arr: TLapeToStrArr);
 var

--- a/lpeval_headers_file.inc
+++ b/lpeval_headers_file.inc
@@ -1,0 +1,22 @@
+{
+  Author: Niels A.D
+  Project: Lape (http://code.google.com/p/la-pe/)
+  License: GNU Lesser GPL (http://www.gnu.org/licenses/lgpl.html)
+
+  This include constains all the headers for the file related wrappers.
+}
+{%MainUnit lpeval.pas}
+
+procedure _LapeExtractFilePath(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExtractFileDrive(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExtractFileName(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExtractFileExt(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExtractFileDir(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExpandFileName(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExtractRelativePath(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeIncludeTrailingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExcludeTrailingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeIncludeTrailingBackslash(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExcludeTrailingBackslash(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeIncludeLeadingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeExcludeLeadingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}

--- a/lpeval_import_file.inc
+++ b/lpeval_import_file.inc
@@ -1,0 +1,24 @@
+{
+  Author: Niels A.D
+  Project: Lape (http://code.google.com/p/la-pe/)
+  License: GNU Lesser GPL (http://www.gnu.org/licenses/lgpl.html)
+
+  This include constains all the wrappers for file related functions.
+}
+{%MainUnit lpcompiler.pas}
+
+addGlobalVar(DirectorySeparator, 'DirectorySeparator').isConstant := True;
+
+addGlobalFunc('function ExtractFilePath(const FileName: String): String;', @_LapeExtractFilePath);
+addGlobalFunc('function ExtractFileDrive(const FileName: String): String;', @_LapeExtractFileDrive);
+addGlobalFunc('function ExtractFileName(const FileName: String): String;', @_LapeExtractFileName);
+addGlobalFunc('function ExtractFileExt(const FileName: String): String;', @_LapeExtractFileExt);
+addGlobalFunc('function ExtractFileDir(const FileName: String): String;', @_LapeExtractFileDir);
+addGlobalFunc('function ExpandFileName(const FileName: String): String;', @_LapeExpandFileName);
+addGlobalFunc('function ExtractRelativepath(const BaseName, DestName: String): String;', @_LapeExtractRelativePath);
+addGlobalFunc('function IncludeTrailingPathDelimiter(const Path: String) : String;', @_LapeIncludeTrailingPathDelimiter);
+addGlobalFunc('function ExcludeTrailingPathDelimiter(const Path: String): String;', @_LapeExcludeTrailingPathDelimiter);
+addGlobalFunc('function IncludeTrailingBackslash(const Path: String) : String;', @_LapeIncludeTrailingBackslash);
+addGlobalFunc('function ExcludeTrailingBackslash(const Path: String): String;', @_LapeExcludeTrailingBackslash);
+addGlobalFunc('function IncludeLeadingPathDelimiter(const Path : String) : String;', @_LapeIncludeLeadingPathDelimiter);
+addGlobalFunc('function ExcludeLeadingPathDelimiter(const Path: String): String;', @_LapeExcludeLeadingPathDelimiter);

--- a/lpeval_wrappers_file.inc
+++ b/lpeval_wrappers_file.inc
@@ -1,0 +1,74 @@
+{
+  Author: Niels A.D
+  Project: Lape (http://code.google.com/p/la-pe/)
+  License: GNU Lesser GPL (http://www.gnu.org/licenses/lgpl.html)
+
+  This include constains all the wrappers for file related functions.
+}
+{%MainUnit lpeval.pas}
+
+procedure _LapeExtractFilePath(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExtractFilePath(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExtractFileDrive(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExtractFileDrive(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExtractFileName(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExtractFileName(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExtractFileExt(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExtractFileExt(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExtractFileDir(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExtractFileDir(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExpandFileName(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExpandFileName(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExtractRelativePath(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExtractRelativePath(PlpString(Params^[0])^, PlpString(Params^[1])^);
+end;
+
+procedure _LapeIncludeTrailingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := IncludeTrailingPathDelimiter(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExcludeTrailingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExcludeTrailingPathDelimiter(PlpString(Params^[0])^);
+end;
+
+procedure _LapeIncludeTrailingBackslash(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := IncludeTrailingBackslash(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExcludeTrailingBackslash(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExcludeTrailingBackslash(PlpString(Params^[0])^);
+end;
+
+procedure _LapeIncludeLeadingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := IncludeLeadingPathDelimiter(PlpString(Params^[0])^);
+end;
+
+procedure _LapeExcludeLeadingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PlpString(Result)^ := ExcludeLeadingPathDelimiter(PlpString(Params^[0])^);
+end;
+

--- a/tests/Parser_Include.lap
+++ b/tests/Parser_Include.lap
@@ -2,6 +2,9 @@
 {$Include_once include.inc}
 
 begin
+  WriteLn('Hi from path: ', {$macro CURRENT_DIRECTORY});
+  WriteLn('Hi from drive: ', ExtractFileDrive({$macro CURRENT_FILE}));
+  
   Included();
   Included_Include();
 end;

--- a/tests/include.inc
+++ b/tests/include.inc
@@ -2,6 +2,6 @@
 
 procedure Included;
 begin
-  WriteLn('Hi from include!: ', {$macro CURRENT_FILE});
+  WriteLn('Hi from include: ', {$macro CURRENT_FILE});
   Included_Include();
 end;


### PR DESCRIPTION
- Added `{$macro CURRENT_DIRECTORY}` to go along with `{$macro CURRENT_FILE}`.
- Imported basic filename parsing methods from SysUtils. 

This could perhaps be expanded on in the future to support file reading & writing?