### PR TITLE
Fix native callback parameters.

### DIFF
--- a/extensions/ffi/lpffiwrappers.pas
+++ b/extensions/ffi/lpffiwrappers.pas
@@ -190,7 +190,7 @@ function _ParseMethodHeader(Compiler: TLapeCompiler; Header: lpString): TLapeTyp
 implementation
 
 uses
-  lpmessages, lpparser, lpeval, lpinterpreter, lpvartypes_array, lpvartypes_record;
+  lpmessages, lpparser, lpeval, lpinterpreter, lpvartypes_array, lpvartypes_record, lpffi;
 
 const
   PowerTwoRegs = [SizeOf(UInt8), SizeOf(UInt16), SizeOf(UInt32), SizeOf(UInt64)];
@@ -764,7 +764,7 @@ begin
   try
     if (VarType.BaseIntType <> ltUnknown) then
       Result.Typ := ConvertBaseIntType(VarType.BaseIntType)
-    else if (VarType.BaseType in LapePointerTypes) then
+    else if (VarType.BaseType in LapePointerTypes) or (VarType is TLapeType_NativeMethod) then
       Result.Typ := ffi_type_pointer
     else
       case VarType.BaseType of

--- a/extensions/ffi/test/LapeTestFFI.lpr
+++ b/extensions/ffi/test/LapeTestFFI.lpr
@@ -3,7 +3,7 @@ program LapeTestFFI;
 uses
   SysUtils, {$IFDEF FPC}LCLIntf,{$ELSE}{$IFDEF MSWINDOWS}Windows,{$ENDIF}{$ENDIF}
   lptypes, lpvartypes, lpcompiler, lptree, lpparser, lpinterpreter, lpmessages,
-  lpffiwrappers, ffi;
+  lpffiwrappers, ffi, lpffi;
 
 type
   TRunFun = function(p: Pointer): Boolean;
@@ -563,6 +563,8 @@ begin
 end;
 
 type
+  TTestCallback = function: Int32; {$I cconv.inc}
+
   TTestObject = object
     MagicToken: NativeInt;
     Success: Boolean;
@@ -574,10 +576,16 @@ type
     function Meth5(const a: TStatPackArr): TStatPackArr; {$I cconv.inc}
     function Meth6(constref a: TStrRec): TStrRec; {$I cconv.inc}
     function Meth7(const a: TLargeRec): TLargeRec; {$I cconv.inc}
+    function Meth8(Func: TTestCallback): Int32; {$I cconv.inc}
   end;
 
 const
   NullTestObject: TTestObject = (MagicToken: 12345; Success: False);
+
+function Callback: Int32; {$I cconv.inc}
+begin
+  Result := 1989;
+end;
 
 procedure TTestObject.Meth1; {$I cconv.inc}
 begin
@@ -731,6 +739,24 @@ begin
   Result := (r.a = 4) and (r.b = 3) and (r.c = 2) and (r.d = 1);
 end;
 
+function TTestObject.Meth8(Func: TTestCallback): Int32; {$I cconv.inc}
+begin
+  Result := Func();
+end;
+
+function RunMeth8(f: Pointer): Boolean;
+type
+  TM = function(Func: TTestCallback): Int32 of object; {$I cconv.inc}
+var
+  m: TM;
+  o: TTestObject;
+begin
+  o := NullTestObject;
+  TMethod(m).Code := f;
+  TMethod(m).Data := @o;
+  Result := TM(m)(@Callback) = 1989;
+end;
+
 function TestBiDiFFI(Header: lpString; ImportFun: Pointer; RunFun: TRunFun; RunStr: lpString = ''; ImportABI: TFFIABI = FFI_DEFAULT_ABI; ExportABI: TFFIABI = FFI_DEFAULT_ABI): Boolean;
 var
   i: TImportClosure;
@@ -750,6 +776,8 @@ begin
   try
     with TLapeCompiler.Create(TLapeTokenizerString.Create('begin ' + RunStr + ' end.')) do
     try
+      InitializeFFI(GetSelf() as TLapeCompiler);
+
       Options := Options + [lcoAssertions];
 
       addGlobalVar(
@@ -757,6 +785,11 @@ begin
         @t,
         'Test'
       );
+
+      addDelayedCode('function LapeCallback: Int32; begin Result := 1989; end;');
+
+      addGlobalType('function: Int32', 'TLapeCallback');
+      addGlobalType('native(TLapeCallback, ' + 'ffi_' + ABIToStr(TEST_ABI) + ')', 'TNativeCallback');
 
       addGlobalType('(ESmallFirst = ' + IntToStr(Ord(Low(ELapeSmallEnum))) + ', ESmallLast = ' + IntToStr(Ord(High(ELapeSmallEnum))) + ')', 'TSmallEnum');
       addGlobalType('(ELargeFirst = ' + IntToStr(Ord(Low(ELapeSmallEnum))) + ', ELargeLast = ' + IntToStr(Ord(High(ELapeLargeEnum))) + ')', 'TLargeEnum');
@@ -810,7 +843,7 @@ begin
       if (i <> nil) then
         i.Free();
       if (e <> nil) then
-        e. Free();
+        e.Free();
     end;
   except
     on E: Exception do
@@ -830,7 +863,7 @@ type
   end;
 
 const
-  BiDiTests: array[1..38] of TRunProc = (
+  BiDiTests: array[1..39] of TRunProc = (
     (Fun: @Proc1;  Run: @RunProc1;  Str: 'procedure Proc1';                                                                                                        Arg: 'TestMe();'),
     (Fun: @Proc2;  Run: @RunProc2;  Str: 'procedure Proc2(a, b, c, d, e, f, g, h, i, j: NativeInt)';                                                               Arg: 'TestMe(1, -2, 3, -4, 5, -6, 7, -8, 9, -10);'),
     (Fun: @Proc3;  Run: @RunProc3;  Str: 'procedure Proc3(a: UInt8; b: Int64; c: UInt32; d: Int16; e: UInt16; f: Int32; g: UInt64; h: Int8)';                      Arg: 'TestMe(1, -2, 3, -4, 5, -6, 7, -8);'),
@@ -870,8 +903,8 @@ const
     (Fun: @TTestObject.Meth4; Run: @RunMeth4; Str: 'function TTest.Meth4(const a, b, c: Int8): UInt8';               Arg: 'Assert(Test.TestMe(15, 14, 13) = 42);'),
     (Fun: @TTestObject.Meth5; Run: @RunMeth5; Str: 'function TTest.Meth5(const a: TStatPackArr): TStatPackArr';      Arg: 'Assert(Test.TestMe([1..3])[2] = 6);'),
     (Fun: @TTestObject.Meth6; Run: @RunMeth6; Str: 'function TTest.Meth6(constref a: TStrRec): TStrRec';             Arg: 'Assert(Test.TestMe(["123"]) = ["0123"]);'),
-    (Fun: @TTestObject.Meth7; Run: @RunMeth7; Str: 'function TTest.Meth7(const a: TLargeRec): TLargeRec';            Arg: 'Assert(Test.TestMe([1, 2, 3, 4]) = [4, 3, 2, 1]);')
-
+    (Fun: @TTestObject.Meth7; Run: @RunMeth7; Str: 'function TTest.Meth7(const a: TLargeRec): TLargeRec';            Arg: 'Assert(Test.TestMe([1, 2, 3, 4]) = [4, 3, 2, 1]);'),
+    (Fun: @TTestObject.Meth8; Run: @RunMeth8; Str: 'function TTest.Meth8(const Func: TNativeCallback): Int32';       Arg: 'Assert(Test.TestMe(@LapeCallback) = 1989);')
   );
 
 {$IF DECLARED(TEST_ABI)}


### PR DESCRIPTION
TLapeType_NativeMethod BaseType is ltUnknown so unable to convert type. Added a VarType check to handle as a pointer.

Seems to fix the issue without breaking anything else i've noticed.