### PR TITLE
Fix access violations at compile time when debugging.

### DIFF
--- a/extensions/ffi/lpffi.pas
+++ b/extensions/ffi/lpffi.pas
@@ -744,7 +744,7 @@ begin
     else
       LapeExceptionFmt(lpeExpected, [FABIType.AsString], [FParams[1], Self]);
 
-  Closure := LapeExportWrapper(FCompiler.Emitter.PCode, nil, Method.Header, Method.ABI);
+  Closure := LapeExportWrapper(FCompiler.Emitter.PCode, FCompiler.Emitter.PCodeLen, nil, Method.Header, Method.ABI);
   if (Closure = nil) then
     LapeException(lpeImpossible, [FParams[0], Self])
   else

--- a/extensions/ffi/test/LapeTestFFI.lpr
+++ b/extensions/ffi/test/LapeTestFFI.lpr
@@ -798,7 +798,7 @@ begin
       e := LapeExportWrapper(m.Method, ExportABI);
 
       Write(Format('Testing  %-6s :: %8s <-> %-8s :: ', [v.Name, ABIToStr(ImportABI), ABIToStr(ExportABI)]));
-      RunCode(Emitter.Code);
+      RunCode(Emitter.Code, Emitter.CodeLen);
       Result := RunFun(e.Func);
 
       if Result then

--- a/lpcodeemitter.pas
+++ b/lpcodeemitter.pas
@@ -52,6 +52,7 @@ type
     procedure _ParamSize(v: TParamSize; Pos: PParamSize); overload; virtual;
 
     function getPCode: Pointer;
+    function getPCodeLen: PInteger;
     procedure IncStack(Size: TStackInc); virtual;
     procedure DecStack(Size: TStackInc); virtual;
   public
@@ -160,6 +161,7 @@ type
     property PCode: Pointer read getPCode;
     property Code: Pointer read _PCode;
     property CodeLen: Integer read FCodeCur;
+    property PCodeLen: PInteger read getPCodeLen;
     property MaxStack: Integer read FMaxStack;
   end;
 
@@ -192,6 +194,11 @@ procedure TLapeCodeEmitterBase._ParamSize(v: TParamSize; Pos: PParamSize);      
 function TLapeCodeEmitterBase.getPCode: Pointer;
 begin
   Result := @_PCode;
+end;
+
+function TLapeCodeEmitterBase.getPCodeLen: PInteger;
+begin
+  Result := @FCodeCur;
 end;
 
 procedure TLapeCodeEmitterBase.IncStack(Size: TStackInc);
@@ -627,7 +634,7 @@ function TLapeCodeEmitterBase._DocPos(Pos: TDocPos): Integer;
   var o: Integer; begin o := -1; Result := _DocPos(Pos, o); end;
 function TLapeCodeEmitterBase._DocPos(Pos: PDocPos): Integer;
   var o: Integer; begin o := -1; Result := _DocPos(Pos, o); end;
-function TLapeCodeEmitterBase._DocPos(): Integer;
+function TLapeCodeEmitterBase._DocPos: Integer;
   var o: Integer; begin o := -1; Result := _DocPos(o); end;
 function TLapeCodeEmitterBase._op(op: opCode; Pos: PDocPos = nil): Integer;
   var o: Integer; begin o := -1; Result := _op(op, o, Pos); end;

--- a/main.pas
+++ b/main.pas
@@ -134,7 +134,7 @@ begin
         begin
           t := GetTickCount64();
           m.Append(LineEnding);
-          RunCode(Compiler.Emitter.Code);
+          RunCode(Compiler.Emitter.Code, Compiler.Emitter.CodeLen);
           m.Append('Running Time: ' + IntToStr(GetTickCount64() - t) + 'ms.');
         end;
       except

--- a/tests/RunTests/lptest.pas
+++ b/tests/RunTests/lptest.pas
@@ -95,7 +95,7 @@ begin
       if (not Compile()) then
         LapeException('Error compiling file')
       else
-        RunCode(Emitter.Code);
+        RunCode(Emitter.Code, Emitter.CodeLen);
     except
       on E: Exception do
       begin


### PR DESCRIPTION
These are only exceptions that get raised while debugging in lazarus:

- Added nil checks to TLapeType_String
- Removed extra pointer debugging, this causes bad stuff to happen which goes unnoticed when not running in a debugger. It's already in a try..except block so I assume it's pretty hacky. The `AVar` value is something random, but low like `4`.