### PR TITLE
Improve some exception messages.

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -2562,7 +2562,7 @@ var
     if (op = op_Dot) then
     begin
       if (Next() <> tk_Identifier) then
-        LapeExceptionFmt(lpeExpected, [LapeTokenToString(tk_Identifier)]);
+        LapeExceptionFmt(lpeExpected, [LapeTokenToString(tk_Identifier)], Tokenizer.DocPos);
       PushVarStack(TLapeTree_Field.Create(Tokenizer.TokString, Self, getPDocPos()));
     end
     else if (op = op_Index) then

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -70,6 +70,7 @@ const
   lpeInvalidIndex = 'Invalid index "%s"';
   lpeInvalidIterator = 'Variable cannot be used for iteration';
   lpeInvalidJump = 'Invalid jump';
+  lpeInvalidOpenArrayIndex = 'Invalid open array index: %d (%s)';
   lpeInvalidOperator = 'Operator "%s" expects %d parameters';
   lpeInvalidRange = 'Expression is not a valid range';
   lpeInvalidUnionType = 'Invalid union type';
@@ -100,6 +101,7 @@ const
   lpeUnknownDeclaration = 'Unknown declaration "%s"';
   lpeUnknownDirective = 'Unknown compiler directive';
   lpeUnknownOC = 'Unknown opcode';
+  lpeUnknownOpenArrayIndex = 'Unknown open array index: %d';
   lpeUnknownParent = 'Cannot find parent declaration';
   lpeVariableExpected = 'Variable expected';
   lpeVariableOfTypeExpected = 'Expected variable of type "%s", got "%s"';

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -70,7 +70,7 @@ const
   lpeInvalidIndex = 'Invalid index "%s"';
   lpeInvalidIterator = 'Variable cannot be used for iteration';
   lpeInvalidJump = 'Invalid jump';
-  lpeInvalidOpenArrayIndex = 'Invalid open array index: %d (%s)';
+  lpeInvalidOpenArrayElement = 'Invalid open array element (%s) (index: %d)';
   lpeInvalidOperator = 'Operator "%s" expects %d parameters';
   lpeInvalidRange = 'Expression is not a valid range';
   lpeInvalidUnionType = 'Invalid union type';
@@ -99,9 +99,9 @@ const
   lpeTypeExpected = 'Type expected';
   lpeUnexpectedToken = 'Found unexpected token "%s"';
   lpeUnknownDeclaration = 'Unknown declaration "%s"';
+  lpeUnknownDeclarationOpenArray = 'Unknown declaration in open array (index: %d)';
   lpeUnknownDirective = 'Unknown compiler directive';
   lpeUnknownOC = 'Unknown opcode';
-  lpeUnknownOpenArrayIndex = 'Unknown open array index: %d';
   lpeUnknownParent = 'Cannot find parent declaration';
   lpeVariableExpected = 'Variable expected';
   lpeVariableOfTypeExpected = 'Expected variable of type "%s", got "%s"';

--- a/lptree.pas
+++ b/lptree.pas
@@ -1619,9 +1619,9 @@ begin
       with FValues[FInvalidCastIndex] as TLapeTree_ExprBase do
       begin
         if resType() <> nil then
-          LapeExceptionFmt(lpeInvalidOpenArrayIndex, [FInvalidCastIndex, resType().AsString], DocPos)
+          LapeExceptionFmt(lpeInvalidOpenArrayElement, [resType().AsString, FInvalidCastIndex], DocPos)
         else
-          LapeExceptionFmt(lpeUnknownOpenArrayIndex, [FInvalidCastIndex], DocPos);
+          LapeExceptionFmt(lpeUnknownDeclarationOpenArray, [FInvalidCastIndex], DocPos);
       end;
     end else
       LapeException(lpeInvalidEvaluation, DocPos);

--- a/lptree.pas
+++ b/lptree.pas
@@ -1114,9 +1114,22 @@ begin
 end;
 
 function TLapeTree_OpenArray.addValue(Val: TLapeTree_Base): Integer;
+var
+  Op: TLapeTree_Operator;
 begin
   if (Val <> nil) then
   begin
+    Op := nil;
+
+    if (Val is TLapeTree_Operator) and (TLapeTree_Operator(Val).resType() = nil) then
+      Op := TLapeTree_Operator(Val)
+    else
+    if (Val is TLapeTree_Invoke) and (TLapeTree_Invoke(Val).resType() = nil) and (TLapeTree_Invoke(Val).Expr is TLapeTree_Operator) then
+      Op := TLapeTree_Operator(TLapeTree_Invoke(Val).Expr);
+
+    if (Op <> nil) and (Op.Right <> nil) and (Op.Right is TLapeTree_Field) and ValidFieldName(TLapeTree_Field(Op.Right).GlobalVar) then
+      LapeExceptionFmt(lpeUnknownDeclaration, [PlpString(TLapeTree_Field(Op.Right).GlobalVar.Ptr)^], Val.DocPos);
+
     Result := FValues.Add(Val);
     Val.Parent := Self;
     ClearCache();


### PR DESCRIPTION
Improved two annoying exception messages that have been a bit annoying to come across over the last 8? years!

1) Added missing DocPos parameter for the exception raised when `Foo.` happens.
2) Added handling for when a method of object or field doesn't exist in a open array.
Previously you just got  ["Invalid evaluation"](https://github.com/nielsAD/lape/blob/master/lptree.pas#L1610) and now you get "Unknown Declaration ..." like in the rest of lape!