### PR TITLE
Allow casting record to a smaller record (most likely parent) if fields match.

### DIFF
--- a/lpvartypes_record.pas
+++ b/lpvartypes_record.pas
@@ -256,10 +256,10 @@ function TLapeType_Record.EvalRes(Op: EOperator; Right: TLapeType = nil; Flags: 
 var
   i: Integer;
 begin
-  if (Right <> nil) and (Right is TLapeType_Record) and  (TLapeType_Record(Right).FieldMap.Count = FFieldMap.Count) then
+  if (Right <> nil) and (Right is TLapeType_Record) and (TLapeType_Record(Right).FieldMap.Count >= FFieldMap.Count) then
     if (op = op_Assign) then
     begin
-      for i := 0 to FFieldMap.Count - 1 do
+      for i := 0 to Min(TLapeType_Record(Right).FieldMap.Count, FFieldMap.Count) - 1 do
         if (FFieldMap.Key[i] <> TLapeType_Record(Right).FieldMap.Key[i]) or
            (not FFieldMap.ItemsI[i].FieldType.CompatibleWith(TLapeType_Record(Right).FieldMap.ItemsI[i].FieldType))
         then


### PR DESCRIPTION
Previously "Invalid Cast" and now works.

```pascal
type
  TPoint = record
    x, y: Integer;
  end;

  TPoint3D = record(TPoint)
     z: Integer;
  end;  

var
  Point3D: TPoint3D = [1, 2, 3];
  Point2D: TPoint;
begin
  WriteLn(TPoint(Point3D));
  
  // Also works. Could be confusing(?) but FPC operates the same way with classes.
  Point2D := Point3D; 
end;
```
Outputs:
```
{X = 1, Y = 2}
```
