### PR TITLE
Fix appending a open array to an array.

### DIFF
--- a/lptree.pas
+++ b/lptree.pas
@@ -4789,7 +4789,11 @@ begin
 
   if (FRight <> nil) then
   begin
-    FRight := FRight.setExpectedType(LeftVar.VarType) as TLapeTree_ExprBase;
+    if (FOperatorType in [op_Plus, op_AssignPlus]) and (LeftVar.VarType is TLapeType_DynArray) then
+      FRight := FRight.setExpectedType(TLapeType_DynArray(LeftVar.VarType).PType) as TLapeTree_ExprBase
+    else
+      FRight := FRight.setExpectedType(LeftVar.VarType) as TLapeTree_ExprBase;
+
     if (FOperatorType = op_Index) then
       FRight := FRight.setExpectedType(FCompiler.getBaseType(ltSizeInt)) as TLapeTree_ExprBase;
 

--- a/tests/Bugs/ArrayAppendOpenArray.lap
+++ b/tests/Bugs/ArrayAppendOpenArray.lap
@@ -1,0 +1,11 @@
+type
+  TPoint = record
+    X, Y: Int32;
+  end;
+  TPointArray = array of TPoint;
+
+var
+  Arr: TPointArray;
+begin
+  Arr := Arr + [1, 2];
+end.


### PR DESCRIPTION
`TPA += [15, 15]` did not compile. The open array would evaluate to `array[0..1] of Integer` therefore `CompatibleWith` in `TLapeType_DynArray.Eval` would fail.

