### PR TITLE
Add finalize management operator (like FPC 3.1.1)

### DIFF
--- a/lpeval.pas
+++ b/lpeval.pas
@@ -192,7 +192,8 @@ var
   _LapeSetLength: lpString =
     'procedure _ArraySetLength(var p: Pointer; NewLen, ElSize: SizeInt;'                 + LineEnding +
     '  Dispose: private procedure(p: Pointer);'                                          + LineEnding +
-    '  Copy: private procedure(Src: ConstPointer; Dst: Pointer));'                       + LineEnding +
+    '  Copy: private procedure(Src: ConstPointer; Dst: Pointer);'                        + LineEnding +
+    '  Finalize: private procedure(p: Pointer));'                                        + LineEnding +
     'const'                                                                              + LineEnding +
     '  HeaderSize = SizeOf(PtrInt) + SizeOf(SizeInt);'                                   + LineEnding +
     'var'                                                                                + LineEnding +
@@ -229,11 +230,17 @@ var
     '      Exit;'                                                                        + LineEnding +
     '    end;'                                                                           + LineEnding +
     ''                                                                                   + LineEnding +
-    '    if (NewLen < OldLen) and (Pointer(Dispose) <> nil) then'                        + LineEnding +
+    '    if (NewLen < OldLen) then'                                                      + LineEnding +
     '    begin'                                                                          + LineEnding +
     '      Inc(p, HeaderSize);'                                                          + LineEnding +
-    '      for i := NewLen * ElSize to (OldLen - 1) * ElSize with ElSize do'             + LineEnding +
-    '        Dispose(p[i]);'                                                             + LineEnding +
+    ''                                                                                   + LineEnding +
+    '      if (Pointer(Finalize) <> nil) then'                                           + LineEnding +
+    '        for i := NewLen * ElSize to (OldLen - 1) * ElSize with ElSize do'           + LineEnding +
+    '          Finalize(p[i]);'                                                          + LineEnding +
+    '      if (Pointer(Dispose) <> nil) then'                                            + LineEnding +
+    '        for i := NewLen * ElSize to (OldLen - 1) * ElSize with ElSize do'           + LineEnding +
+    '          Dispose(p[i]);'                                                           + LineEnding +
+    ''                                                                                   + LineEnding +
     '      Dec(p, HeaderSize);'                                                          + LineEnding +
     '    end;'                                                                           + LineEnding +
     ''                                                                                   + LineEnding +
@@ -256,7 +263,7 @@ var
     '  begin'                                                                            + LineEnding +
     '    Dec(PtrInt(p^));'                                                               + LineEnding +
     '    NewP := nil;'                                                                   + LineEnding +
-    '    _ArraySetLength(NewP, NewLen, ElSize, Dispose, Copy);'                          + LineEnding +
+    '    _ArraySetLength(NewP, NewLen, ElSize, Dispose, Copy, Finalize);'                + LineEnding +
     ''                                                                                   + LineEnding +
     '    i := OldLen;'                                                                   + LineEnding +
     '    if (NewLen < OldLen) then'                                                      + LineEnding +
@@ -292,7 +299,7 @@ var
     '  else if (Len - Count < Start) then'                                               + LineEnding +
     '    Count := Len - Start;'                                                          + LineEnding +
     ''                                                                                   + LineEnding +
-    '  _ArraySetLength(Result, Count, ElSize, nil, nil);'                                + LineEnding +
+    '  _ArraySetLength(Result, Count, ElSize, nil, nil, nil);'                                + LineEnding +
     '  Inc(p, Start * ElSize);'                                                          + LineEnding +
     ''                                                                                   + LineEnding +
     '  if (Pointer(Copy) = nil) then'                                                    + LineEnding +
@@ -307,7 +314,8 @@ var
     '  Start: SizeInt; Count: SizeInt = High(SizeInt);'                                  + LineEnding +
     '  ElSize: SizeInt;'                                                                 + LineEnding +
     '  Dispose: private procedure(p: Pointer);'                                          + LineEnding +
-    '  Copy: private procedure(Src: ConstPointer; Dst: Pointer));'                       + LineEnding +
+    '  Copy: private procedure(Src: ConstPointer; Dst: Pointer);'                        + LineEnding +
+    '  Finalize: private procedure(p: Pointer));'                                        + LineEnding +
     'type'                                                                               + LineEnding +
     '  PSizeInt = ^SizeInt;'                                                             + LineEnding +
     'var'                                                                                + LineEnding +
@@ -324,7 +332,7 @@ var
     '  else if (Len - Count < Start) then'                                               + LineEnding +
     '    Count := Len - Start;'                                                          + LineEnding +
     ''                                                                                   + LineEnding +
-    '  _ArraySetLength(p, Len, ElSize, Dispose, Copy);'                                  + LineEnding +
+    '  _ArraySetLength(p, Len, ElSize, Dispose, Copy, Finalize);'                        + LineEnding +
     '  Inc(p, Start * ElSize);'                                                          + LineEnding +
     ''                                                                                   + LineEnding +
     '  if (Pointer(Dispose) <> nil) then'                                                + LineEnding +
@@ -335,14 +343,15 @@ var
     '    Move(p[Count * ElSize]^, p^, (Len - Start - Count) * ElSize);'                  + LineEnding +
     ''                                                                                   + LineEnding +
     '  Dec(p, Start * ElSize);'                                                          + LineEnding +
-    '  _ArraySetLength(p, Len-Count, ElSize, nil, nil);'                                 + LineEnding +
+    '  _ArraySetLength(p, Len-Count, ElSize, nil, nil, nil);'                            + LineEnding +
     'end;';
 
   _LapeInsert: lpString =
     'procedure _ArrayInsert(Src: ConstPointer; var Dst: Pointer;'                        + LineEnding +
     '  Start: SizeInt = 0; Count: SizeInt = 0; LenSrc, ElSize: SizeInt;'                 + LineEnding +
     '  Dispose: private procedure(p: Pointer);'                                          + LineEnding +
-    '  Copy: private procedure(Src: ConstPointer; Dst: Pointer));'                       + LineEnding +
+    '  Copy: private procedure(Src: ConstPointer; Dst: Pointer);'                        + LineEnding +
+    '  Finalize: private procedure(p: Pointer));'                                        + LineEnding +
     'type'                                                                               + LineEnding +
     '  PSizeInt = ^SizeInt;'                                                             + LineEnding +
     'var'                                                                                + LineEnding +
@@ -363,7 +372,7 @@ var
     '  else if (LenDst - Count < Start) then'                                            + LineEnding +
     '    Count := LenDst - Start;'                                                       + LineEnding +
     ''                                                                                   + LineEnding +
-    '  _ArraySetLength(Dst, LenDst + LenSrc, ElSize, Dispose, Copy);'                    + LineEnding +
+    '  _ArraySetLength(Dst, LenDst + LenSrc, ElSize, Dispose, Copy, Finalize);'          + LineEnding +
     '  Inc(Dst, Start * ElSize);'                                                        + LineEnding +
     ''                                                                                   + LineEnding +
     '  if (Count <> LenSrc) then'                                                        + LineEnding +
@@ -389,7 +398,7 @@ var
     '      Copy(Src[i], Dst[i]);'                                                        + LineEnding +
     ''                                                                                   + LineEnding +
     '  Dec(Dst, Start * ElSize);'                                                        + LineEnding +
-    '  _ArraySetLength(Dst, LenDst + LenSrc - Count, ElSize, nil, nil);'                 + LineEnding +
+    '  _ArraySetLength(Dst, LenDst + LenSrc - Count, ElSize, nil, nil, nil);'            + LineEnding +
     'end;';
 
 implementation

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -56,6 +56,7 @@ const
   lpeExceptionIn = '%s in file "%s"';
   lpeExpected = '%s expected';
   lpeExpectedOther = 'Found unexpected token "%s", expected "%s"';
+  lpeExpectedVarParameter = 'Expected var parameter (index: %d)';
   lpeExpressionExpected = 'Expression expected';
   lpeFileNotFound = 'File "%s" not found';
   lpeImpossible = 'It''s impossible!';
@@ -72,6 +73,7 @@ const
   lpeInvalidIndex = 'Invalid index "%s"';
   lpeInvalidIterator = 'Variable cannot be used for iteration';
   lpeInvalidJump = 'Invalid jump';
+  lpeInvalidManagementMethod = 'Invalid mangment method "%s"';
   lpeInvalidOpenArrayElement = 'Invalid open array element (%s) (index: %d)';
   lpeInvalidOperator = 'Operator "%s" expects %d parameters';
   lpeInvalidRange = 'Expression is not a valid range';
@@ -80,6 +82,7 @@ const
   lpeInvalidWithReference = 'Invalid with-reference';
   lpeLostClosingParenthesis = 'Found closing parenthesis without matching opening parenthesis';
   lpeLostConditional = 'Found conditional without matching opening statement';
+  lpeManagementMethodNotSupported = 'Management method not supported for type "%s"';
   lpeMethodOfObjectExpected = 'Expected method of object';
   lpeNoDefaultForParam = 'No default value for parameter %d found';
   lpeNoForwardMatch = 'Forwarded declaration doesn''t match';

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -30,6 +30,7 @@ type
     tk_kw_Array,
     tk_kw_Begin,
     tk_kw_Case,
+    tk_kw_Class,
     tk_kw_Const,
     tk_kw_ConstRef,
     tk_kw_Deprecated,
@@ -249,7 +250,7 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..51 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..52 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';           Token: tk_op_AND),
       (Keyword: 'DIV';           Token: tk_op_DIV),
       (Keyword: 'IN';            Token: tk_op_IN),
@@ -264,6 +265,7 @@ const
       (Keyword: 'ARRAY';         Token: tk_kw_Array),
       (Keyword: 'BEGIN';         Token: tk_kw_Begin),
       (Keyword: 'CASE';          Token: tk_kw_Case),
+      (Keyword: 'CLASS';         Token: tk_kw_Class),
       (Keyword: 'CONST';         Token: tk_kw_Const),
       (Keyword: 'CONSTREF';      Token: tk_kw_ConstRef),
       (Keyword: 'DEPRECATED';    Token: tk_kw_Deprecated),

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -595,6 +595,7 @@ const
   AssignOperators = [op_Assign] + CompoundOperators;
 
   OverloadableOperators = [op_Assign, op_Plus, op_Minus, op_Multiply, op_Divide, op_DIV, op_Power, op_MOD, op_IN, op_IS, op_SHL, op_SHR] + CompareOperators + BinaryOperators + CompoundOperators;
+  FinalizeOperatorTypes = [ltRecord];
 
   op_str: array[EOperator] of lpString = ('',
     '=', '>', '>=', '<', '<=', '<>', '@', 'and', ':=', '/=', '-=', '*=', '+=',
@@ -629,6 +630,7 @@ function LapeCase(const Str: lpString): lpString; {$IFDEF Lape_Inline}inline;{$E
 function LapeHash(const Value: lpString): UInt32;
 function LapeTypeToString(Token: ELapeBaseType): lpString; {$IFDEF Lape_Inline}inline;{$ENDIF}
 function LapeOperatorToString(Token: EOperator): lpString; {$IFDEF Lape_Inline}inline;{$ENDIF}
+function LapeIsFinalizeOperator(const Value: lpString): Boolean;
 
 function PointerToString(const p: Pointer): lpString;
 {$IF NOT(DECLARED(UIntToStr))}
@@ -733,6 +735,11 @@ function LapeOperatorToString(Token: EOperator): lpString;
 begin
   Result := lpString(getEnumName(TypeInfo(EOperator), Ord(Token)));
   Delete(Result, 1, 3);
+end;
+
+function LapeIsFinalizeOperator(const Value: lpString): Boolean;
+begin
+  Result := UpperCase(Value) = '!FINALIZE';
 end;
 
 function PointerToString(const p: Pointer): lpString;

--- a/lpvartypes_record.pas
+++ b/lpvartypes_record.pas
@@ -67,7 +67,7 @@ implementation
 
 uses
   Math,
-  lpvartypes_array, lpparser, lpeval, lpmessages;
+  lpvartypes_array, lpparser, lpeval, lpmessages, lptree;
 
 function TLapeType_Record.getAsString: lpString;
 var
@@ -400,6 +400,15 @@ begin
   else if (op = op_Assign) and Right.HasType() and CompatibleWith(Right.VarType) then
     if (not NeedInitialization) and Equals(Right.VarType) and (Size > 0) and ((Left.VarPos.MemPos <> mpStack) or (DetermineIntType(Size, False) <> ltUnknown)) then
     begin
+      if TLapeTree_InternalMethod_Finalize.NeedFinalize(FCompiler, Left) then
+        with TLapeTree_InternalMethod_Finalize.Create(FCompiler, Pos) do
+        try
+          addParam(TLapeTree_ResVar.Create(Left.IncLock(), FCompiler, Pos));
+          Compile(Offset).Spill(1);
+        finally
+          Free();
+        end;
+
       Left.VarType := FCompiler.getBaseType(DetermineIntType(Size, False));
 
       if Left.HasType() then

--- a/tests/Record_Finalize.lap
+++ b/tests/Record_Finalize.lap
@@ -1,0 +1,99 @@
+type
+  TPoint = record
+    X, Y: Integer;
+  end;
+  TPointArray = array of TPoint;
+
+procedure TestContainers;
+var
+  Dyn: TPointArray;
+  Stat: array[0..1] of TPointArray;
+  Rec: record
+    Rec: record
+      Dyn: TPointArray;
+      Stat: array[0..1] of TPointArray;
+    end;
+  end;
+begin
+  SetLength(Dyn, 10);
+
+  Dyn[0].X := 100;
+  Dyn[0].Y := 100;
+  Dyn += [200, 200];
+
+  Stat[1] += [300, 300];
+
+  with Rec.Rec do
+  begin
+    SetLength(Dyn, 10);
+
+    Dyn[0].X := 400;
+    Dyn[0].Y := 400;
+    Dyn += [500, 500];
+
+    Stat[1] += [600, 600];
+  end;
+end;
+
+procedure TestAssignment;
+var
+  P: TPoint;
+begin
+  P := [100, 100];
+  WriteLn '>> Assign >>';
+  P := [200, 200];
+  WriteLn '<< Assign <<';
+end;
+
+procedure TestSetLength;
+var
+  Arr: array of TPointArray;
+begin
+  SetLength(Arr, 10, 10);
+
+  Arr[0][0] := [100, 100];
+  Arr[5][6] := [200, 200];
+  Arr[6][6] := [300, 300];
+
+  WriteLn '>> Clear >>';
+  SetLength(Arr, 1);
+  WriteLn '>> Clear <<';
+end;
+
+procedure TestMethod;
+
+  function Method(out P1: TPoint; var P2: TPoint; const P3: TPoint; constref P4: TPoint; P5: TPoint): TPoint;
+  begin
+    Result := [600, 600];
+  end;
+
+var
+  P1, P2, P3, P4, P5, P6: TPoint;
+begin
+  P1 := [100, 100];
+  P2 := [200, 200];
+  P3 := [300, 300];
+  P4 := [400, 400];
+  P5 := [500, 500];
+  WriteLn '>> Invoke >>';
+  P6 := Method(P1, P2, P3, P4, P5);
+  WriteLn '<< Invoke <<';
+end;
+
+class operator TPoint.Finalize(var P: TPoint);
+begin
+  WriteLn('Finalize: ', P);
+end;
+
+var
+  Rec: TPoint := [100, 100];
+  Dyn: TPointArray := [[200, 200]];
+  Stat: array[0..0] of TPoint := [[300, 300]];
+
+begin
+  WriteLn '>> TestContainers >> '; TestContainers(); WriteLn '<< TestContainers <<';
+  WriteLn '>> TestAssignment >>'; TestAssignment(); WriteLn '<< TestAssignment <<';
+  WriteLn '>> TestSetLength >>'; TestSetLength(); WriteLn '<< TestSetLength <<';
+  WriteLn '>> TestMethod >>'; TestMethod(); WriteLn '<< TestMethod <<';
+  WriteLn '>> TestConstants >>';
+end.

--- a/tests/Record_Finalize.txt
+++ b/tests/Record_Finalize.txt
@@ -1,0 +1,36 @@
+>> TestContainers >> 
+Finalize: {X = 100, Y = 100}
+Finalize: {X = 200, Y = 200}
+Finalize: {X = 300, Y = 300}
+Finalize: {X = 400, Y = 400}
+Finalize: {X = 500, Y = 500}
+Finalize: {X = 600, Y = 600}
+<< TestContainers <<
+>> TestAssignment >>
+>> Assign >>
+Finalize: {X = 100, Y = 100}
+<< Assign <<
+Finalize: {X = 200, Y = 200}
+<< TestAssignment <<
+>> TestSetLength >>
+>> Clear >>
+Finalize: {X = 200, Y = 200}
+Finalize: {X = 300, Y = 300}
+>> Clear <<
+Finalize: {X = 100, Y = 100}
+<< TestSetLength <<
+>> TestMethod >>
+>> Invoke >>
+Finalize: {X = 500, Y = 500}
+<< Invoke <<
+Finalize: {X = 100, Y = 100}
+Finalize: {X = 200, Y = 200}
+Finalize: {X = 300, Y = 300}
+Finalize: {X = 400, Y = 400}
+Finalize: {X = 500, Y = 500}
+Finalize: {X = 600, Y = 600}
+<< TestMethod <<
+>> TestConstants >>
+Finalize: {X = 100, Y = 100}
+Finalize: {X = 200, Y = 200}
+Finalize: {X = 300, Y = 300}


### PR DESCRIPTION
I've added the finalize operator from FPC 3.1.1 [management operators](https://wiki.freepascal.org/management_operators).

```pascal
class operator TPoint.Finalize(var P: TPoint);
begin
  WriteLn('Finalize: ', P);
end;
```

It behaves same apart from:
- Finalize **is** called on assignment.
- Finalize **isn't** called if the record is untouched and contains default values.

Notes:
- Compiling speeds are untouched and are actually a tad faster (for SRL at least) since magic methods are now [cached](https://github.com/ollydev/lape/blob/643141f295cf6f5327d2ce5ea8caa9f578d8b994/lptree.pas#L861).
- The `_Dispose` method is now internal and the `{$fulldisposal}` switch has been removed.
- Initializing with a constant multi dimensional open array (below) will not get finalized as it contains a reference to a global variable. Only applies to arrays evaluated as a constant so it shouldn't be a problem.
```pascal
procedure Test;
var
  TPA: T2DPointArray;
begin
  TPA := [[[10, 10], [20, 20], [30, 30], [40, 40], [50, 50], [60, 60]]];
end;
```