### PR TITLE
Records: Add class variables/constants

### DIFF
--- a/lpparser.pas
+++ b/lpparser.pas
@@ -30,6 +30,7 @@ type
     tk_kw_Array,
     tk_kw_Begin,
     tk_kw_Case,
+    tk_kw_Class,
     tk_kw_Const,
     tk_kw_ConstRef,
     tk_kw_Deprecated,
@@ -249,7 +250,7 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..51 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..52 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';           Token: tk_op_AND),
       (Keyword: 'DIV';           Token: tk_op_DIV),
       (Keyword: 'IN';            Token: tk_op_IN),
@@ -264,6 +265,7 @@ const
       (Keyword: 'ARRAY';         Token: tk_kw_Array),
       (Keyword: 'BEGIN';         Token: tk_kw_Begin),
       (Keyword: 'CASE';          Token: tk_kw_Case),
+      (Keyword: 'CLASS';         Token: tk_kw_Class),
       (Keyword: 'CONST';         Token: tk_kw_Const),
       (Keyword: 'CONSTREF';      Token: tk_kw_ConstRef),
       (Keyword: 'DEPRECATED';    Token: tk_kw_Deprecated),

--- a/tests/Record_ClassVar.lap
+++ b/tests/Record_ClassVar.lap
@@ -1,0 +1,49 @@
+{$assertions on}
+
+type
+  TPoint = record
+  class var
+    ClassVar1: Int32 = 100;
+    ClassVar2: Int32 = 200;
+  class const
+    ClassConst1,
+    ClassConst2 = 'Hello World';
+  var
+    X, Y: Int32;
+  end;
+
+procedure Test;
+type
+  TPoint3D = record(TPoint)
+  class const
+    ClassVar3: Int32 = 300;
+  var
+    Z: Int32;
+  end;
+begin
+  with TPoint3D([100, 200, 300]) do
+  begin
+    Assert(X = ClassVar1);
+    Assert(Y = ClassVar2);
+    Assert(Z = ClassVar3);
+
+    ClassVar1 := 1000;
+    ClassVar2 := 2000;
+  end;
+end;
+
+var
+  P: TPoint;
+
+begin
+  Assert(TPoint.ClassVar1 = 100);
+  Assert(TPoint.ClassVar2 = 200);
+
+  Assert(TPoint.ClassConst1 = 'Hello World');
+  Assert(TPoint.ClassConst2 = 'Hello World');
+
+  Test();
+
+  Assert(P.ClassVar1 = 1000);
+  Assert(P.ClassVar2 = 2000);
+end.


### PR DESCRIPTION
Like FPC's advanced records I've added support for class variables and constants.
```pascal
type
  TPoint = record
  class var
    ClassVar1: Int32 = 100;
    ClassVar2: Int32 = 200;
  class const
    ClassConst1,
    ClassConst2 = 'Hello World';
  var
    X, Y: Int32;
  end;
```

It's quite simple, it just references a global variable internally. 

Default value assignments **must** be constants, Allowing `:=` would be pretty weird in this instance, plus we'd have to find somewhere to compile the assignments - not worth it.