### PR TITLE
Add memory management operators (AddRef & Finalize)

### DIFF
--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -65,6 +65,7 @@ const
   lpeIncompatibleOperator2 = 'Operator "%s" not compatible with types "%s" and "%s"';
   lpeInvalidAssignment = 'Invalid assignment';
   lpeInvalidCast = 'Invalid cast';
+  lpeInvalidClassOperatorMethod = 'Invalid class operator method';
   lpeInvalidCondition = 'Invalid condition';
   lpeInvalidEvaluation = 'Invalid evaluation';
   lpeInvalidForward = 'Forwarded declaration "%s" not resolved';
@@ -74,6 +75,7 @@ const
   lpeInvalidJump = 'Invalid jump';
   lpeInvalidOpenArrayElement = 'Invalid open array element (%s) (index: %d)';
   lpeInvalidOperator = 'Operator "%s" expects %d parameters';
+  lpeInvalidParameterModifier = 'Invalid parameter modifier at index %d';
   lpeInvalidRange = 'Expression is not a valid range';
   lpeInvalidUnionType = 'Invalid union type';
   lpeInvalidValueForType = 'Invalid value for type "%s"';

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -30,6 +30,7 @@ type
     tk_kw_Array,
     tk_kw_Begin,
     tk_kw_Case,
+    tk_kw_Class,
     tk_kw_Const,
     tk_kw_ConstRef,
     tk_kw_Deprecated,
@@ -249,7 +250,7 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..51 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..52 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';           Token: tk_op_AND),
       (Keyword: 'DIV';           Token: tk_op_DIV),
       (Keyword: 'IN';            Token: tk_op_IN),
@@ -264,6 +265,7 @@ const
       (Keyword: 'ARRAY';         Token: tk_kw_Array),
       (Keyword: 'BEGIN';         Token: tk_kw_Begin),
       (Keyword: 'CASE';          Token: tk_kw_Case),
+      (Keyword: 'CLASS';         Token: tk_kw_Class),
       (Keyword: 'CONST';         Token: tk_kw_Const),
       (Keyword: 'CONSTREF';      Token: tk_kw_ConstRef),
       (Keyword: 'DEPRECATED';    Token: tk_kw_Deprecated),

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -21,7 +21,6 @@ type
     lcoRangeCheck,                     // {$R} {$RANGECHECKS}      TODO
     lcoShortCircuit,                   // {$B} {$BOOLEVAL}
     lcoAlwaysInitialize,               // {$M} {$MEMORYINIT}
-    lcoFullDisposal,                   // {$D} {$FULLDISPOSAL}
     lcoLooseSemicolon,                 // {$L} {$LOOSESEMICOLON}
     lcoLooseSyntax,                    // {$X} {$EXTENDEDSYNTAX}
     lcoAutoInvoke,                     // {$F} {$AUTOINVOKE}
@@ -31,13 +30,15 @@ type
     lcoHints,                          // {$H} {$HINTS}
     lcoContinueCase,                   //      {$CONTINUECASE}
     lcoCOperators,                     //      {$COPERATORS}
+    lcoAddRefOperator,
+    lcoFinalizeOperator,
     lcoInitExternalResult              // Ensure empty result for external calls (useful for ffi)
   );
   ECompilerOptionsSet = set of ECompilerOption;
   PCompilerOptionsSet = ^ECompilerOptionsSet;
 
 const
-  Lape_OptionsDef = [lcoCOperators, lcoRangeCheck, lcoHints, lcoShortCircuit, lcoAlwaysInitialize, lcoAutoInvoke, lcoConstAddress];
+  Lape_OptionsDef = [lcoAddRefOperator, lcoFinalizeOperator, lcoCOperators, lcoRangeCheck, lcoHints, lcoShortCircuit, lcoAlwaysInitialize, lcoAutoInvoke, lcoConstAddress];
   Lape_PackRecordsDef = 8;
 
 type
@@ -122,6 +123,7 @@ type
     function getHi: TLapeGlobalVar; virtual;
     function getInitialization: Boolean; virtual;
     function getFinalization: Boolean; virtual;
+    function getFinalizeOperator: Boolean; virtual;
 
     function getReadable: Boolean; virtual;
     procedure setReadable(AReadable: Boolean); virtual;
@@ -144,6 +146,7 @@ type
     property Hi: TLapeGlobalVar read getHi;
     property NeedInitialization: Boolean read getInitialization;
     property NeedFinalization: Boolean read getFinalization;
+    property NeedFinalizeOperator: Boolean read getFinalizeOperator;
 
     property Readable: Boolean read getReadable write setReadable;
     property Writeable: Boolean read getWriteable write setWriteable;
@@ -174,6 +177,8 @@ type
     function Declock(Count: Integer = 1): Integer; virtual;
     property Locked: Boolean read getLocked write setLocked;
   end;
+
+  TLapeStackResultVar = class(TLapeStackTempVar);
 
   TLapeParameterVar = class(TLapeStackVar)
   protected
@@ -226,6 +231,7 @@ type
     FCompiler: TLapeCompilerBase;
     FSize: SizeInt;
     FInit: TInitBool;
+    FFinalizeOperator: TInitBool;
     FStatic: Boolean;
 
     FLo: TLapeGlobalVar;
@@ -236,12 +242,15 @@ type
     function getEvalProc(Op: EOperator; Left, Right: ELapeBaseType): TLapeEvalProc; virtual;
 
     procedure setBaseType(ABaseType: ELapeBaseType); virtual;
+    procedure setNeedFinalizeOperator(Value: Boolean); virtual;
+
     function getBaseIntType: ELapeBaseType; virtual;
     function getPadding: SizeInt; virtual;
     function getSize: SizeInt; virtual;
     function getInitialization: Boolean; virtual;
     function getFinalization: Boolean; virtual;
     function getAsString: lpString; virtual;
+    function getFinalizeOperator: Boolean; virtual;
   public
     TypeID: Integer;
 
@@ -290,6 +299,7 @@ type
     property IsStatic: Boolean read FStatic;
     property NeedInitialization: Boolean read getInitialization;
     property NeedFinalization: Boolean read getFinalization;
+    property NeedFinalizeOperator: Boolean read getFinalizeOperator write setNeedFinalizeOperator;
     property AsString: lpString read getAsString;
   end;
 
@@ -322,6 +332,7 @@ type
   protected
     FPType: TLapeType;
     FPConst: Boolean;
+
     function getAsString: lpString; override;
   public
     constructor Create(ACompiler: TLapeCompilerBase; PointerType: TLapeType = nil; ConstPointer: Boolean = True; AName: lpString = ''; ADocPos: PDocPos = nil); reintroduce; virtual;
@@ -366,7 +377,9 @@ type
     FreeParams: Boolean;
     ImplicitParams: Integer;
     Res: TLapeType;
+    OperatorType: EOperator;
     IsOperator: Boolean;
+    IsClassOperator: Boolean;
     HintDirectives: ELapeHintDirectives;
     DeprecatedHint: String;
 
@@ -536,9 +549,8 @@ type
     CodePos: Integer;
 
     ForceInitialization: Boolean;
-    FullDisposal: Boolean;
 
-    constructor Create(AlwaysInitialize: Boolean = True; ForceDisposal: Boolean = False; AOwner: TLapeStackInfo = nil; ManageVars: Boolean = True); reintroduce; virtual;
+    constructor Create(AlwaysInitialize: Boolean = True; AOwner: TLapeStackInfo = nil; ManageVars: Boolean = True); reintroduce; virtual;
     destructor Destroy; override;
     procedure Clear; override;
 
@@ -551,7 +563,8 @@ type
     function addVar(StackVar: TLapeStackVar): TLapeStackVar; overload; virtual;
     function addVar(VarType: TLapeType; Name: lpString = ''): TLapeStackVar; overload; virtual;
     function addVar(ParType: ELapeParameterType; VarType: TLapeType; Name: lpString = ''): TLapeStackVar; overload; virtual;
-    function addSelfVar(ParType: ELapeParameterType; VarType: TLapeType): TLapeStackVar; overload; virtual;
+    function addSelfVar(ParType: ELapeParameterType; VarType: TLapeType): TLapeStackVar; virtual;
+    function addResultVar(VarType: TLapeType): TLapeStackVar; virtual;
 
     function inheritVar(StackVar: TLapeStackVar): TLapeStackVar; virtual;
     function getInheritedVar(StackVar: TLapeStackVar): TLapeStackVar; virtual;
@@ -988,6 +1001,14 @@ begin
   Writeable := Other.Writeable;
 end;
 
+function TLapeVar.getFinalizeOperator: Boolean;
+begin
+  if HasType() then
+    Result := VarType.NeedFinalizeOperator
+  else
+    Result := False;
+end;
+
 function TLapeVar.getBaseType: ELapeBaseType;
 begin
   if HasType() then
@@ -1372,6 +1393,14 @@ begin
   FBaseType := ABaseType;
 end;
 
+procedure TLapeType.setNeedFinalizeOperator(Value: Boolean);
+begin
+  if Value then
+    FFinalizeOperator := bTrue
+  else
+    FFinalizeOperator := bFalse;
+end;
+
 function TLapeType.getBaseIntType: ELapeBaseType;
 begin
   if (not (FBaseType in LapeOrdinalTypes{ + [ltPointer]})) then
@@ -1533,6 +1562,11 @@ end;
 function TLapeType.IsOrdinal(OrPointer: Boolean = False): Boolean;
 begin
   Result := (BaseIntType <> ltUnknown) or (OrPointer and (BaseType = ltPointer));
+end;
+
+function TLapeType.getFinalizeOperator: Boolean;
+begin
+  Result := FFinalizeOperator = bTrue;
 end;
 
 function TLapeType.HasChild(AName: lpString): Boolean;
@@ -2162,10 +2196,9 @@ end;
 
 function TLapeType_Pointer.Equals(Other: TLapeType; ContextOnly: Boolean = True): Boolean;
 begin
-  if ContextOnly and (Other <> nil) and (Other.TypeID = TypeID) and (ClassType = Other.ClassType) and (Other.BaseType = BaseType) then
-    Result := (not HasType()) or (not TLapeType_Pointer(Other).HasType()) or inherited
-  else
-    Result := inherited;
+  Result := (Other is TLapeType_Pointer) and
+            ((HasType and PType.Equals(TLapeType_Pointer(Other).PType, ContextOnly)) or (not HasType) and (not TLapeType_Pointer(Other).HasType)) and
+            inherited;
 end;
 
 function TLapeType_Pointer.VarToStringBody(ToStr: TLapeType_OverloadedMethod = nil): lpString;
@@ -3430,7 +3463,7 @@ begin
   Result := False;
 end;
 
-constructor TLapeStackInfo.Create(AlwaysInitialize: Boolean = True; ForceDisposal: Boolean = False; AOwner: TLapeStackInfo = nil; ManageVars: Boolean = True);
+constructor TLapeStackInfo.Create(AlwaysInitialize: Boolean = True; AOwner: TLapeStackInfo = nil; ManageVars: Boolean = True);
 begin
   inherited Create(nil, False);
 
@@ -3441,7 +3474,6 @@ begin
   CodePos := -1;
 
   ForceInitialization := AlwaysInitialize;
-  FullDisposal := ForceDisposal;
 end;
 
 destructor TLapeStackInfo.Destroy;
@@ -3576,6 +3608,11 @@ begin
   Result := addVar(ParType, VarType, 'Self');
 end;
 
+function TLapeStackInfo.addResultVar(VarType: TLapeType): TLapeStackVar;
+begin
+  Result := addVar(TLapeStackResultVar.Create(VarType, nil));
+end;
+
 function TLapeStackInfo.inheritVar(StackVar: TLapeStackVar): TLapeStackVar;
 begin
   Assert(StackVar <> nil);
@@ -3615,7 +3652,7 @@ end;
 constructor TLapeDeclStack.Create(AList: TLapeManagingDeclaration; AOwner: TLapeStackInfo = nil);
 begin
   Assert(AList <> nil);
-  inherited Create(False, False, AOwner, False);
+  inherited Create(False, AOwner, False);
 
   Parent := AList.ManagedDeclarations;
   FManagingList := AList;
@@ -4070,7 +4107,7 @@ end;
 
 function TLapeCompilerBase.IncStackInfo(var Offset: Integer; Emit: Boolean = True; Pos: PDocPos = nil): TLapeStackInfo;
 begin
-  Result := IncStackInfo(TLapeStackInfo.Create(lcoAlwaysInitialize in FOptions, lcoFullDisposal in FOptions, FStackInfo), Offset, Emit, Pos);
+  Result := IncStackInfo(TLapeStackInfo.Create(lcoAlwaysInitialize in FOptions, FStackInfo), Offset, Emit, Pos);
 end;
 
 function TLapeCompilerBase.IncStackInfo(Emit: Boolean = False): TLapeStackInfo;
@@ -4108,12 +4145,14 @@ var
 
   function NeedFinalization(v: TLapeVar): Boolean;
   begin
-    Result := v <> nil;
-    if Result then
-      if (not FStackInfo.FullDisposal) then
-        Result := v.NeedFinalization
-      else if (v is TLapeParameterVar) then
-        Result := (not (TLapeParameterVar(v).ParType in Lape_RefParams));
+    Result := False;
+
+    if (v <> nil) then
+    begin
+      Result := v.NeedFinalization;
+      if (not Result) and v.NeedFinalizeOperator then
+        Result := (not (v is TLapeParameterVar)) or (TLapeParameterVar(v).ParType = lptNormal);
+    end;
   end;
 
 begin
@@ -4186,9 +4225,7 @@ begin
         Emitter._InitStackLen(Emitter.MaxStack, InitStackPos, Pos)
       else
         RemoveInitStack();
-    end
-    else
-      FStackInfo.FullDisposal := lcoFullDisposal in FOptions;
+    end;
 
     Emitter.NewStack(FStackInfo.FOldStackPos, FStackInfo.FOldMaxStack);
     if DoFree then

--- a/tests/Operators_MemoryManagement.lap
+++ b/tests/Operators_MemoryManagement.lap
@@ -1,0 +1,248 @@
+{$hints off}
+{$assertions on}
+
+type
+  TManagedRecord = record
+    MyObject: Int32;
+    Ref: ^Int32;
+  end;
+
+  TContainer = record
+    Obj: TManagedRecord;
+  end;
+
+  TArr = array of TManagedRecord;
+  TStaticArr = array[0..1] of TManagedRecord;
+
+var
+  Initialized: Int32;
+  Finalized: array of Int32;
+
+class operator TManagedRecord.AddRef(var Obj: TManagedRecord);
+begin
+  Assert(Obj.Ref <> nil);
+
+  Obj.Ref^ += 1;
+end;
+
+class operator TManagedRecord.Finalize(var Obj: TManagedRecord);
+var
+  i: Int32;
+begin
+  Assert(Obj.Ref <> nil);
+  Assert(Obj.Ref^ > 0);
+
+  Dec(Obj.Ref^);
+  if (Obj.Ref^ > 0) then
+    Exit;
+
+  // Check double finalize
+  for i := 0 to High(Finalized) do
+    Assert(Finalized[i] <> Obj.MyObject);
+  Finalized += Obj.MyObject;
+
+  FreeMem(Obj.Ref);
+end;
+
+function getManagedRecord: TManagedRecord;
+begin
+  Result.MyObject := Inc(Initialized);
+  Result.Ref := GetMem(SizeOf(Int32));
+  Result.Ref^ := 1;
+end;
+
+function getContainer: TContainer;
+begin
+  Result.Obj := getManagedRecord();
+end;
+
+function getArray: TArr;
+begin
+  SetLength(Result, 2);
+
+  Result[0] := getManagedRecord();
+  Result[1] := getManagedRecord();
+end;
+
+function getStaticArray: TStaticArr;
+begin
+  Result[0] := getManagedRecord();
+  Result[1] := getManagedRecord();
+end;
+
+procedure TestArray;
+var
+  A, B: TArr;
+  R: TManagedRecord;
+  I: Int32;
+begin
+  A := [getManagedRecord(), getManagedRecord()] + [getManagedRecord(), getManagedRecord(), getManagedRecord(), getManagedRecord()];
+  A := [];
+
+  // Open array still hold references, will be finalized when method cleans up.
+  Assert(Length(Finalized) = 0);
+
+  SetLength(A, 5);
+  for I := 0 to High(A) do
+    A[I] := getManagedRecord();
+
+  B := Copy(A);
+  A := [];
+
+  // B holds references now
+  Assert(Length(Finalized) = 0);
+
+  B := [];
+
+  // B is no more!
+  Assert(Length(Finalized) = 5);
+
+  for I := 0 to High(A) do
+    Insert(getManagedRecord(), A);
+  Delete(A, 0, Length(A));
+
+  Assert(Length(Finalized) = 5);
+end;
+
+procedure TestUnassigned;
+begin
+  getManagedRecord();
+  getManagedRecord();
+
+  with getManagedRecord(), getManagedRecord() do
+    ;
+
+  for 1 to 6 do
+    getManagedRecord();
+
+  Assert(Length(Finalized) = 5); // Only overwrites in the for loop, others will be finalized when method cleans up.
+end;
+
+procedure TestMethod_Array;
+var
+  a, b, c, d, e, f: TArr;
+
+  function Method(var a: TArr; out b: TArr; c: TArr; const d: TArr; constref e: TArr): TArr; static;
+  begin
+    a := getArray();
+    b := getArray();
+    c := getArray();
+
+    Result := getArray();
+  end;
+
+begin
+  a := getArray();
+  b := getArray();
+  c := getArray();
+  d := getArray();
+  e := getArray();
+  f := getArray();
+
+  for 1 to 2 do
+    f := Method(a, b, c, d, e);
+
+  Assert(Length(Finalized) = 16);
+end;
+
+procedure TestMethod_StaticArray;
+var
+  a, b, c, d, e, f: TStaticArr;
+
+  function Method(var a: TStaticArr; out b: TStaticArr; c: TStaticArr; const d: TStaticArr; constref e: TStaticArr): TStaticArr; static;
+  begin
+    a := getStaticArray();
+    b := getStaticArray();
+    c := getStaticArray();
+
+    Result := getStaticArray();
+  end;
+
+begin
+  a := getStaticArray();
+  b := getStaticArray();
+  c := getStaticArray();
+  d := getStaticArray();
+  e := getStaticArray();
+  f := getStaticArray();
+
+  for 1 to 2 do
+    f := Method(a, b, c, d, e);
+
+  Assert(Length(Finalized) = 16);
+end;
+
+procedure TestMethod_Container;
+var
+  a, b, c, d, e, f: TContainer;
+
+  function Method(var a: TContainer; out b: TContainer; c: TContainer; const d: TContainer; constref e: TContainer): TContainer; static;
+  begin
+    a := getContainer();
+    b := getContainer();
+    c := getContainer();
+
+    Result := getContainer();
+  end;
+
+begin
+  a := getContainer();
+  b := getContainer();
+  c := getContainer();
+  d := getContainer();
+  e := getContainer();
+  f := getContainer();
+
+  for 1 to 2 do
+    f := Method(a, b, c, d, e);
+
+  Assert(Length(Finalized) = 8);
+end;
+
+procedure TestMethod;
+
+  function Method(var a: TManagedRecord; out b: TManagedRecord; c: TManagedRecord; const d: TManagedRecord; constref e: TManagedRecord): TManagedRecord; static;
+  begin
+    a := getManagedRecord();
+    b := getManagedRecord();
+    c := getManagedRecord();
+
+    Result := getManagedRecord();
+  end;
+
+var
+  a, b, c, d, e, f: TManagedRecord;
+begin
+  a := getManagedRecord();
+  b := getManagedRecord();
+  c := getManagedRecord();
+  d := getManagedRecord();
+  e := getManagedRecord();
+  f := getManagedRecord();
+
+  for 1 to 2 do
+    f := Method(a, b, c, d, e);
+
+  Assert(Length(Finalized) = 8);
+end;
+
+procedure Test(Proc: procedure; Name: String);
+begin
+  Initialized := 0;
+  Finalized := [];
+
+  Proc();
+
+  WriteLn(Name, ' -> ', Initialized, ' :: ', Length(Finalized));
+  Assert(Initialized = Length(Finalized), Name);
+end;
+
+begin
+  Test(@TestMethod,             'TestMethod');
+  Test(@TestMethod_Array,       'TestMethod_Array');
+  Test(@TestMethod_StaticArray, 'TestMethod_StaticArray');
+  Test(@TestMethod_Container,   'TestMethod_Container');
+
+  Test(@TestArray, 'TestArray');
+  Test(@TestUnassigned, 'TestUnassigned');
+end.


### PR DESCRIPTION
Added class operators `AddRef` and `Finalize`. The user must implement their own refcounting if needed:

```pascal
type
  TManagedRecord = record
    MyObject: Int32;
    Ref: ^Int32;
  end;

class operator TManagedRecord.AddRef(var Obj: TManagedRecord);
begin
  Assert(Obj.Ref <> nil);

  Obj.Ref^ += 1;
end;

class operator TManagedRecord.Finalize(var Obj: TManagedRecord);
var
  i: Int32;
begin
  Assert(Obj.Ref <> nil);
  Assert(Obj.Ref^ > 0);

  Dec(Obj.Ref^);
  if (Obj.Ref^ > 0) then
    Exit;

  // Free stuff here!

  FreeMem(Obj.Ref);
end;

function GetManagedRecord: TManagedRecord;
begin
  Result.MyObject := 123;
  Result.Ref := GetMem(SizeOf(Int32));
  Result.Ref^ := 1;
end;
```

Perhaps in the future an magic record can be added to inherit from which would do the refcounting internally? 

----

Most of the work is on in `TLapeTree_Operator.Compile` when assigning:

- If `Left` is writable: Call `Finalize`
- If `Right` isn't a constant: Call `AddRef`
- After assignment if `Right` is an `TLapeTree_Invoke` result call `VarToDefault` to prevent double finalizing when the function cleans up.

Other changes:

- Replaced `Eval(op_Assign)` calls with `TLapeTree_Operator.Create(op_Assign)` so these management operators are considered.
- Skip writable check in `TLapeTree_Operator` only if `Left.VarPos.MemPos=mpStack`. Assume the stack has been correctly grown if `Left` is constant and so on.
- Check `PType` in `TLapeType_Pointer.Equals`
- Remove full disposal mode, The finalize operator can be used to replace this.
- Removed operator method parsing from `ParseMethod` by adding `ParseOperatorMethod`. `lpcompiler.pas` diff is large due to mostly changing the indent of `ParseMethod`.
- `_Dispose` is now generated  if type has finalize/addref operator and calls finalize operator.
- `_Assign` is now generated if type has finalize/addref operator.