### PR TITLE
Allow type declarations in internal method parameters

### DIFF
--- a/package/lape.lpk
+++ b/package/lape.lpk
@@ -16,7 +16,7 @@
       <CodeGeneration>
         <SmartLinkUnit Value="True"/>
         <Optimizations>
-          <OptimizationLevel Value="3"/>
+          <OptimizationLevel Value="2"/>
           <UncertainOptimizations Value="True"/>
         </Optimizations>
       </CodeGeneration>


### PR DESCRIPTION
The following is now possible:
```pascal
type 
  TFoo = native(type procedure(a: Int32));
```