### PR TITLE
Add "Objectify" magic method.

### DIFF
--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -55,6 +55,7 @@ const
   lpeExceptionAt = '%s at line %d, column %d';
   lpeExceptionIn = '%s in file "%s"';
   lpeExpected = '%s expected';
+  lpeExpectedNormalMethod = 'Normal method expected';
   lpeExpectedOther = 'Found unexpected token "%s", expected "%s"';
   lpeExpressionExpected = 'Expression expected';
   lpeFileNotFound = 'File "%s" not found';

--- a/tests/Method_Objectify.lap
+++ b/tests/Method_Objectify.lap
@@ -1,0 +1,33 @@
+{$assertions on}
+{$autoobjectify on}
+
+function Rand(Min, Max: Int64): Int64;
+begin
+  Result := Random(Min, Max);
+end;
+
+function Test1(Callback: function(Min, Max: Int64): Int64 of object): Int64;
+begin
+  Result := Callback(10,10);
+end;
+
+function Test2(Callback: function(Min, Max: Int64): Int64): Int64;
+begin
+  Result := Objectify(@Callback)(10,10);
+end;
+
+begin
+  // ltScriptMethod
+  Assert(Test1(@Rand)=10);
+  Assert(Test2(@Rand)=10);
+
+  Assert(Objectify(@Rand)(10,10)=10);
+  Assert(Objectify(@Rand)(10,10)=10);
+
+  // ltImportedMethod
+  Assert(Test1(@Random[0])=10);
+  Assert(Test2(@Random[0])=10);
+
+  Assert(Objectify(@Random[0])(10,10)=10);
+  Assert(Objectify(@Random[0])(10,10)=10);
+end;


### PR DESCRIPTION
Allows assignment of non-object methods to object method callbacks.

```pascal
function Test: String;
begin
  Result := 'Hello world';
end;

var
  Callback: function: String of object;

begin
  Callback := @Test;

  WriteLn Callback(); // Hello world
end;
```