### PR TITLE
Compile time optimization

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -3563,7 +3563,7 @@ function TLapeCompiler.Compile: Boolean;
     Decl: TLapeGlobalVar;
     i: Integer;
   begin
-    Decls := GlobalDeclarations.getByClass(TLapeGlobalVar, bFalse);
+    Decls := GlobalDeclarations.GetAll(TLapeGlobalVar, bFalse);
     for i := 0 to High(Decls) do
     begin
       Decl := Decls[i] as TLapeGlobalVar;
@@ -3786,12 +3786,14 @@ begin
 end;
 
 function TLapeCompiler.addGlobalVar(AVar: TLapeGlobalVar; AName: lpString = ''): TLapeGlobalVar;
+var
+  Decl: TLapeDeclaration;
 begin
   if (AVar <> nil) then
   begin
     if (AName <> '') then
       AVar.Name := AName;
-    if (Length(FGlobalDeclarations.getByName(AVar.Name, bTrue)) > 0) then
+    if FGlobalDeclarations.Get(AVar.Name, Decl, bTrue) then
       LapeExceptionFmt(lpeDuplicateDeclaration, [AVar.Name]);
     AVar.isConstant := False;
     FGlobalDeclarations.addDeclaration(AVar);
@@ -3811,7 +3813,6 @@ begin
   try
     ParseVarBlock().Free();
     Result := getGlobalVar(AName);
-    //Result := FGlobalDeclarations.Items[FGlobalDeclarations.Items.Count - 1] as TLapeGlobalVar;
     CheckAfterCompile();
   finally
     resetTokenizerState(OldState);
@@ -3920,6 +3921,8 @@ begin
 end;
 
 function TLapeCompiler.addGlobalType(Typ: TLapeType; AName: lpString = ''; ACopy: Boolean = True): TLapeType;
+var
+  Decl: TLapeDeclaration;
 begin
   if (Typ <> nil) then
   begin
@@ -3927,7 +3930,7 @@ begin
       SetUniqueTypeID(Typ);
     if (AName <> '') then
       Typ.Name := AName;
-    if (Length(FGlobalDeclarations.getByName(Typ.Name, bTrue)) > 0) then
+    if FGlobalDeclarations.Get(Typ.Name, Decl, bTrue) then
       LapeExceptionFmt(lpeDuplicateDeclaration, [Typ.Name]);
     FGlobalDeclarations.addDeclaration(Typ);
   end;
@@ -3944,7 +3947,6 @@ begin
   try
     ParseTypeBlock();
     Result := getGlobalType(AName);
-    //Result := FGlobalDeclarations.Items[FGlobalDeclarations.Items.Count - 1] as TLapeType;
     CheckAfterCompile();
   finally
     resetTokenizerState(OldState);

--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -3563,7 +3563,7 @@ function TLapeCompiler.Compile: Boolean;
     Decl: TLapeGlobalVar;
     i: Integer;
   begin
-    Decls := GlobalDeclarations.GetAll(TLapeGlobalVar, bFalse);
+    Decls := GlobalDeclarations.GetByClass(TLapeGlobalVar, bFalse);
     for i := 0 to High(Decls) do
     begin
       Decl := Decls[i] as TLapeGlobalVar;

--- a/lpeval.pas
+++ b/lpeval.pas
@@ -831,6 +831,8 @@ end;
 {$WARN COMPARING_SIGNED_UNSIGNED OFF}
 {$WARN IMPLICIT_STRING_CAST OFF}
 {$WARN IMPLICIT_STRING_CAST_LOSS OFF}
+{$WARN 6058 off} // has not been inlined warning
+
 {$I lpeval_functions.inc}
 
 procedure LoadEvalArr(var Arr: TLapeEvalArr);

--- a/lpinterpreter.pas
+++ b/lpinterpreter.pas
@@ -538,14 +538,14 @@ var
       HandleSafeJump();
   end;
 
-  procedure DoInvokeImportedProc(RecSize: Integer; Ptr: Pointer; ParamSize: UInt16; StackPosOffset: Integer = 0); {$IFDEF Lape_Inline}inline;{$ENDIF}
+  procedure DoInvokeImportedProc(RecSize: Integer; Ptr: Pointer; ParamSize: TParamSize; StackPosOffset: TStackInc = 0); {$IFDEF Lape_Inline}inline;{$ENDIF}
   begin
     TLapeImportedProc(Ptr)(@Stack[StackPos - ParamSize]);
     Dec(StackPos, ParamSize - StackPosOffset);
     Inc(Code, RecSize + ocSize);
   end;
 
-  procedure DoInvokeImportedFunc(RecSize: Integer; Ptr, Res: Pointer; ParamSize: UInt16; StackPosOffset: Integer = 0); {$IFDEF Lape_Inline}inline;{$ENDIF}
+  procedure DoInvokeImportedFunc(RecSize: Integer; Ptr, Res: Pointer; ParamSize: TParamSize; StackPosOffset: TStackInc = 0); {$IFDEF Lape_Inline}inline;{$ENDIF}
   begin
     TLapeImportedFunc(Ptr)(@Stack[StackPos - ParamSize], Res);
     Dec(StackPos, ParamSize - StackPosOffset);

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -51,6 +51,7 @@ const
   lpeDeclarationOutOfScope = 'Declaration "%s" out of scope';
   lpeDefaultToMoreThanOne = 'Runtime default value can only be assigned to one variable';
   lpeDuplicateDeclaration = 'Duplicate declaration "%s"';
+  lpeDuplicateHashBucket = 'Duplicate hash bucket with "%s" and "%s"';
   lpeErrorScanningString = '%s while scanning string literal';
   lpeExceptionAt = '%s at line %d, column %d';
   lpeExceptionIn = '%s in file "%s"';
@@ -77,6 +78,7 @@ const
   lpeInvalidJump = 'Invalid jump';
   lpeInvalidOpenArrayElement = 'Invalid open array element (%s) (index: %d)';
   lpeInvalidOperator = 'Operator "%s" expects %d parameters';
+  lpeInvalidDictionaryOperation = 'Invalid operation (%s) on dictionary';
   lpeInvalidRange = 'Expression is not a valid range';
   lpeInvalidUnionType = 'Invalid union type';
   lpeInvalidValueForType = 'Invalid value for type "%s"';

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -313,9 +313,6 @@ const
       (Keyword: 'WITH';          Token: tk_kw_With)
     );
 
-  LapeKeyword_MinLength = 2;
-  LapeKeyword_MaxLength = 13;
-
   OperatorAssociative: array[EOperator] of EOperatorAssociative = (
     assocNone,                          //op_Unkown
 
@@ -693,20 +690,14 @@ var
   function Alpha: EParserToken; inline;
   var
     Token: EParserToken;
-    TokenLen: Integer;
   begin
     while (getChar(1) in ['0'..'9', 'A'..'Z', '_', 'a'..'z']) do
       Inc(FPos);
 
-    TokenLen := getTokLen();
-    if (TokenLen >= LapeKeyword_MinLength) and (TokenLen <= LapeKeyword_MaxLength) then
-    begin
-      Token := FKeywordDictionary[getTokString()];
-      if (Token <> tk_Unknown) then
-        Result := setTok(Token)
-      else
-        Result := setTok(tk_Identifier);
-    end else
+    Token := FKeywordDictionary[getTokString()];
+    if (Token <> tk_Unknown) then
+      Result := setTok(Token)
+    else
       Result := setTok(tk_Identifier);
   end;
 
@@ -1117,7 +1108,7 @@ begin
   FOnParseDirective := nil;
   FOnHandleDirective := nil;
 
-  FKeywordDictionary := TLapeKeywordDictionary.Create(tk_Unknown, 2048);
+  FKeywordDictionary := TLapeKeywordDictionary.Create(tk_Unknown, 512);
   for i := 0 to High(Lape_Keywords) do
     FKeywordDictionary[Lape_Keywords[i].Keyword] := Lape_Keywords[i].Token;
 

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -19,7 +19,7 @@ type
   EParserToken = (
     //General
     tk_NULL,
-    tk_Unkown,
+    tk_Unknown,
     tk_Identifier,
     tk_Comment,
     tk_Directive,
@@ -140,6 +140,13 @@ type
   TLapeParseDirective = function(Sender: TLapeTokenizerBase): Boolean of object;
   TLapeHandleDirective = function(Sender: TLapeTokenizerBase; Directive, Argument: lpString): Boolean of object;
 
+  TLapeKeyword = record
+    Keyword: lpString;
+    Token: EParserToken;
+  end;
+
+  TLapeKeywordDictionary = specialize TLapeUniqueDictionary<EParserToken>;
+
   TLapeTokenizerBase = class(TLapeBaseDeclClass)
   protected
     FFileName: lpString;
@@ -153,6 +160,8 @@ type
 
     FOnParseDirective: TLapeParseDirective;
     FOnHandleDirective: TLapeHandleDirective;
+
+    FKeywordDictionary: TLapeKeywordDictionary;
 
     function Compare(Key: lpString): Boolean; virtual; abstract;
     function Identify: EParserToken; virtual;
@@ -173,6 +182,7 @@ type
     NullPos: TDocPos;
 
     constructor Create(AFileName: lpString = ''); reintroduce; virtual;
+    destructor Destroy; override;
     procedure Reset(ClearDoc: Boolean = False); virtual;
     function getState: Pointer; virtual;
     procedure setState(const State: Pointer; DoFreeState: Boolean = True); virtual;
@@ -226,11 +236,6 @@ type
   public
     constructor Create(AFileName: UnicodeString = ''); reintroduce; overload; virtual;
     constructor Create(AFileName: AnsiString = ''); reintroduce; overload; virtual;
-  end;
-
-  TLapeKeyword = record
-    Keyword: lpString;
-    Token: EParserToken;
   end;
 
 const
@@ -307,6 +312,9 @@ const
       (Keyword: 'WHILE';         Token: tk_kw_While),
       (Keyword: 'WITH';          Token: tk_kw_With)
     );
+
+  LapeKeyword_MinLength = 2;
+  LapeKeyword_MaxLength = 13;
 
   OperatorAssociative: array[EOperator] of EOperatorAssociative = (
     assocNone,                          //op_Unkown
@@ -386,21 +394,14 @@ const
     3                                   //op_UnaryPlus
   );
 
-var
-  {$IFDEF Lape_DoubleKeywordsCache}
-  Lape_KeywordsCache: array[2..13, Byte] of array of TLapeKeyword;
-  {$ELSE}
-  Lape_KeywordsCache: array[Byte] of array of TLapeKeyword;
-  {$ENDIF}
-
-  {$IF NOT DECLARED(FormatSettings)}
-  FormatSettings: TFormatSettings
+{$IF NOT DECLARED(FormatSettings)}
+  var FormatSettings: TFormatSettings
     {$IF DECLARED(DefaultFormatSettings)}
     absolute DefaultFormatSettings
     {$ELSE}
     {$DEFINE LoadDefaultFormatSettings}
     {$IFEND};
-  {$IFEND}
+{$IFEND}
 
 function LapeTokenToString(Token: EParserToken): lpString; {$IFDEF Lape_Inline}inline;{$ENDIF}
 function ParserTokenToOperator(Token: EParserToken): EOperator; {$IFDEF Lape_Inline}inline;{$ENDIF}
@@ -668,102 +669,12 @@ begin
   end;
 end;
 
-function Lape_HashKeyword(const Str: lpString): Byte;
-var
-  i: Integer;
-begin
-  //Str := UpperCase(Str);
-  Result := Length(Str);
-  for i := 1 to Length(Str) do
-    Result := Byte(Result - 128) xor Byte((Ord(Str[i]) - 65) shl ((i + 2) mod 8));
-end;
-
-function Lape_IsKeyword(Str: lpString; out Token: EParserToken): Boolean;
-var
-  Hash: Byte;
-  i: Integer;
-  {$IFDEF Lape_DoubleKeywordsCache}
-  StrLen: Integer;
-  {$ENDIF}
-begin
-  {$IFDEF Lape_DoubleKeywordsCache}
-  StrLen := Length(Str);
-  if (StrLen < Low(Lape_KeywordsCache)) or (StrLen > High(Lape_KeywordsCache)) then
-    Exit(False);
-  {$ENDIF}
-
-  Str := UpperCase(Str);
-  Hash := Lape_HashKeyword(Str);
-
-  {$IFDEF Lape_DoubleKeywordsCache}
-  for i := High(Lape_KeywordsCache[StrLen][Hash]) downto 0 do
-    if (CompareStr(Lape_KeywordsCache[StrLen][Hash][i].Keyword, Str) = 0) then
-    begin
-      Token := Lape_KeywordsCache[StrLen][Hash][i].Token;
-      Exit(True);
-    end;
-  {$ELSE}
-  for i := High(Lape_KeywordsCache[Hash]) downto 0 do
-    if (CompareStr(Lape_KeywordsCache[Hash][i].Keyword, b) = 0) then
-    begin
-      Token := Lape_KeywordsCache[Hash][i].Token;
-      Exit(True);
-    end;
-  {$ENDIF}
-  Result := False;
-end;
-
-procedure Lape_ClearKeywordsCache;
-var
-  i: Integer;
-  {$IFDEF Lape_DoubleKeywordsCache}
-  ii: Integer;
-  {$ENDIF}
-begin
-  {$IFDEF Lape_DoubleKeywordsCache}
-  for i := Low(Lape_KeywordsCache) to High(Lape_KeywordsCache) do
-    for ii := Low(Lape_KeywordsCache[i]) to High(Lape_KeywordsCache[i]) do
-      Lape_KeywordsCache[i][ii] := nil;
-  {$ELSE}
-  for i := Low(Lape_KeywordsCache) to High(Lape_KeywordsCache) do
-    Lape_KeywordsCache[i] := nil;
-  {$ENDIF}
-end;
-
-procedure Lape_InitKeywordsCache;
-var
-  Hash: Byte;
-  i: Integer;
-  {$IFDEF Lape_DoubleKeywordsCache}
-  StrLen: Integer;
-  {$ENDIF}
-begin
-  Lape_ClearKeywordsCache();
-
-  {$IFDEF Lape_DoubleKeywordsCache}
-  for i := Low(Lape_Keywords) to High(Lape_Keywords) do
-  begin
-    Hash := Lape_HashKeyword(UpperCase(Lape_Keywords[i].Keyword));
-    StrLen := Length(Lape_Keywords[i].Keyword);
-    SetLength(Lape_KeywordsCache[StrLen][Hash], Length(Lape_KeywordsCache[StrLen][Hash]) + 1);
-    Lape_KeywordsCache[StrLen][Hash][High(Lape_KeywordsCache[StrLen][Hash])] := Lape_Keywords[i];
-  end;
-  {$ELSE}
-  for i := Low(Lape_Keywords) to High(Lape_Keywords) do
-  begin
-    Hash := Lape_HashKeyword(UpperCase(Lape_Keywords[i].Keyword));
-    SetLength(Lape_KeywordsCache[Hash], Length(Lape_KeywordsCache[Hash]) + 1);
-    Lape_KeywordsCache[Hash][High(Lape_KeywordsCache[Hash])] := Lape_Keywords[i];
-  end;
-  {$ENDIF}
-end;
-
 function TLapeTokenizerBase.Identify: EParserToken;
 var
   Char: lpChar;
-  tmpDocPos:TDocPos;
+  tmpDocPos: TDocPos;
   
-  procedure NextPos_CountLines;
+  procedure NextPos_CountLines; inline;
   begin
     repeat
       case CurChar of
@@ -779,23 +690,23 @@ var
     until (not (CurChar in [#9, #32, #10, #13]));
   end;
 
-  function Alpha: EParserToken;
+  function Alpha: EParserToken; inline;
   var
-    Str: lpString;
     Token: EParserToken;
+    TokenLen: Integer;
   begin
-    Str := Char;
-    Char := getChar(1);
-    while (Char in ['0'..'9', 'A'..'Z', '_', 'a'..'z']) do
-    begin
+    while (getChar(1) in ['0'..'9', 'A'..'Z', '_', 'a'..'z']) do
       Inc(FPos);
-      Str := Str + Char;
-      Char := getChar(1);
-    end;
 
-    if Lape_IsKeyword(Str, Token) then
-      Result := setTok(Token)
-    else
+    TokenLen := getTokLen();
+    if (TokenLen >= LapeKeyword_MinLength) and (TokenLen <= LapeKeyword_MaxLength) then
+    begin
+      Token := FKeywordDictionary[getTokString()];
+      if (Token <> tk_Unknown) then
+        Result := setTok(Token)
+      else
+        Result := setTok(tk_Identifier);
+    end else
       Result := setTok(tk_Identifier);
   end;
 
@@ -878,14 +789,15 @@ begin
         else
           Result := setTok(tk_op_Divide);
       end;
-          
- 
+
     {Minus, AssignMinus} 
-    '-':if (getChar(1) = '=') then begin
-          Result := setTok(tk_op_AssignMinus);
-          Inc(FPos);
-        end else 
-          Result := setTok(tk_op_Minus);
+    '-':
+      if (getChar(1) = '=') then
+      begin
+        Result := setTok(tk_op_AssignMinus);
+        Inc(FPos);
+      end else
+        Result := setTok(tk_op_Minus);
     
     {Multiply, Power, AssignMul}      
     '*':
@@ -903,15 +815,16 @@ begin
         else
           Result := setTok(tk_op_Multiply);
       end;
-      
-    
+
     {Plus, AssignPlus}
-    '+':if (getChar(1) = '=') then begin
-          Result := setTok(tk_op_AssignPlus);
-          Inc(FPos);
-        end else 
-          Result := setTok(tk_op_Plus);
-    
+    '+':
+      if (getChar(1) = '=') then
+      begin
+        Result := setTok(tk_op_AssignPlus);
+        Inc(FPos);
+      end else
+        Result := setTok(tk_op_Plus);
+
     '@': Result := setTok(tk_op_Addr);
     '^': Result := setTok(tk_sym_Caret);
 
@@ -920,31 +833,29 @@ begin
     '[': Result := setTok(tk_sym_BracketOpen);
     ',': Result := setTok(tk_sym_Comma);
     '.':
+      if (getChar(1) = '.') then
       begin
-        if (getChar(1) = '.') then
-        begin
-          Inc(FPos);
-          Result := setTok(tk_sym_DotDot);
-        end
-        else
-          Result := setTok(tk_op_Dot);
-      end;
+        Inc(FPos);
+        Result := setTok(tk_sym_DotDot);
+      end
+      else
+        Result := setTok(tk_op_Dot);
+
     ')': Result := setTok(tk_sym_ParenthesisClose);
     '(':
+      if (getChar(1) = '*') then
       begin
-        if (getChar(1) = '*') then
-        begin
-          Inc(FPos, 2);
-          while (not ((CurChar in ['*', #0]) and (getChar(1) in [')', #0]))) do
-            NextPos_CountLines();
+        Inc(FPos, 2);
+        while (not ((CurChar in ['*', #0]) and (getChar(1) in [')', #0]))) do
+          NextPos_CountLines();
 
-          Result := setTok(tk_Comment);
-          if (CurChar = '*') then
-            Inc(FPos);
-        end
-        else
-          Result := setTok(tk_sym_ParenthesisOpen);
-      end;
+        Result := setTok(tk_Comment);
+        if (CurChar = '*') then
+          Inc(FPos);
+      end
+      else
+        Result := setTok(tk_sym_ParenthesisOpen);
+
     ';': Result := setTok(tk_sym_SemiColon);
     '{':
       begin
@@ -994,27 +905,23 @@ begin
         end;
       end;
     '$':
+      if (getChar(1) in ['0'..'9', 'A'..'F', 'a'..'f']) then
       begin
-        if (getChar(1) in ['0'..'9', 'A'..'F', 'a'..'f']) then
-        begin
-          Inc(FPos);
-          while (getChar(1) in ['0'..'9', 'A'..'F', 'a'..'f', '_']) do Inc(FPos);
-          Result := setTok(tk_typ_Integer_Hex);
-        end
-        else
-          Result := setTok(tk_Unkown);
-      end;
+        Inc(FPos);
+        while (getChar(1) in ['0'..'9', 'A'..'F', 'a'..'f', '_']) do Inc(FPos);
+        Result := setTok(tk_typ_Integer_Hex);
+      end
+      else
+        Result := setTok(tk_Unknown);
     '%':
+      if (getChar(1) in ['0'..'1']) then
       begin
-        if (getChar(1) in ['0'..'1']) then
-        begin
-          Inc(FPos);
-          while (getChar(1) in ['0'..'1', '_']) do Inc(FPos);
-          Result := setTok(tk_typ_Integer_Bin);
-        end
-        else
-          Result := setTok(tk_Unkown);
-      end;
+        Inc(FPos);
+        while (getChar(1) in ['0'..'1', '_']) do Inc(FPos);
+        Result := setTok(tk_typ_Integer_Bin);
+      end
+      else
+        Result := setTok(tk_Unknown);
     'A'..'Z', '_', 'a'..'z': Result := Alpha();
     #34: //heredoc string
       begin
@@ -1052,16 +959,14 @@ begin
                 Result := setTok(tk_typ_Char);
               end
               else
-                Result := setTok(tk_Unkown);
+                Result := setTok(tk_Unknown);
             end;
           else
-            Result := setTok(tk_Unkown);
+            Result := setTok(tk_Unknown);
         end;
       end;
     else
-    begin
-      Result := setTok(tk_Unkown);
-    end;
+      Result := setTok(tk_Unknown);
   end;
 end;
 
@@ -1132,7 +1037,7 @@ begin
 end;
 
 function TLapeTokenizerBase.getTokUInt64: UInt64;
-  function Bin2Dec(s: lpString): UInt64;
+  function Bin2Dec(s: lpString): UInt64; inline;
   var
     i: Integer;
   begin
@@ -1203,12 +1108,18 @@ begin
 end;
 
 constructor TLapeTokenizerBase.Create(AFileName: lpString = '');
+var
+  i: Integer;
 begin
   inherited Create();
 
   FFileName := AFileName;
   FOnParseDirective := nil;
   FOnHandleDirective := nil;
+
+  FKeywordDictionary := TLapeKeywordDictionary.Create(tk_Unknown, 2048);
+  for i := 0 to High(Lape_Keywords) do
+    FKeywordDictionary[Lape_Keywords[i].Keyword] := Lape_Keywords[i].Token;
 
   OverridePos := nil;
   NullPos := NullDocPos;
@@ -1219,6 +1130,13 @@ begin
   end;
 
   Reset();
+end;
+
+destructor TLapeTokenizerBase.Destroy;
+begin
+  FreeAndNil(FKeywordDictionary);
+
+  inherited Destroy();
 end;
 
 procedure TLapeTokenizerBase.Reset(ClearDoc: Boolean = False);
@@ -1267,7 +1185,7 @@ begin
   Dispose(PTokenizerState(State));
 end;
 
-function TLapeTokenizerBase.TempRollBack: EParserToken;
+function TLapeTokenizerBase.tempRollBack: EParserToken;
 begin
   Result := FTok;
   FTok := FLastTok;
@@ -1445,11 +1363,9 @@ begin
 end;
 
 initialization
-  Lape_InitKeywordsCache();
   {$IFDEF LoadDefaultFormatSettings}
   GetLocaleFormatSettings(0, FormatSettings);
   {$ENDIF}
-finalization
-  Lape_ClearKeywordsCache();
+
 end.
 

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -162,6 +162,7 @@ type
     ltDynArray, ltStaticArray,                                                //Array
     ltScriptMethod, ltImportedMethod                                          //Methods
   );
+
   LapeIntegerTypeRange = ltUInt8..ltInt64;
 
   EOperatorAssociative = (assocNone, assocLeft, assocRight);
@@ -249,7 +250,7 @@ type
   {$IFDEF FPC}generic{$ENDIF} TLapeStack<_T> = class(TLapeBaseClass)
   public type
     TTArray = array of _T;
-  var protected
+  protected
     FArr: TTArray;
     FLen: Integer;
     FCur: Integer;
@@ -281,7 +282,7 @@ type
   {$IFDEF FPC}generic{$ENDIF} TLapeList<_T> = class(TLapeBaseClass)
   public type
     TTArray = {$IFDEF Delphi}TArray<_T>{$ELSE}array of _T{$ENDIF};
-  var protected
+  protected
     FDuplicates: TDuplicates;
     FSorted: Boolean;
     FItems: TTArray;
@@ -359,7 +360,7 @@ type
       Keys: {$IFDEF Delphi}TArray<lpString>{$ELSE}TLapeStringList.TTArray{$ENDIF};
       Items: {$IFDEF Delphi}TTItems.TTArray{$ELSE}array of _T{$ENDIF};
     end;
-  var protected
+  protected
     FStringList: TLapeStringList;
     FItems: TTItems;
     FCount: Integer;
@@ -407,6 +408,7 @@ type
     property Sorted: Boolean read getSorted write setSorted;
   end;
 
+  // Must be large enough not to have multiple values fall into the same bucket
   {$IFDEF FPC}generic{$ENDIF} TLapeUniqueDictionary<_T> = class(TLapeBaseClass)
   protected type
     TBucket = record Name: lpString; Value: _T; end;
@@ -414,6 +416,8 @@ type
   protected
     FArr: TArr;
     FSize: Integer;
+    FMinLength: Integer;
+    FMaxLength: Integer;
 
     procedure setValue(Key: lpString; Value: _T);
     function getValue(Key: lpString): _T;
@@ -429,7 +433,7 @@ type
   public type
     TNotifyProc = procedure(Sender: _T);
     TNotifiers = {$IFDEF FPC}specialize{$ENDIF} TLapeList<TNotifyProc>;
-  var protected
+  protected
     FNotifiers: TNotifiers;
   public
     constructor Create; reintroduce; virtual;
@@ -443,66 +447,112 @@ type
 
   {$IFDEF FPC}generic{$ENDIF} TLapeNotifierOfObject<_T> = class(TLapeBaseClass)
   public type
-     TNotifyProcOfObject = procedure(Sender: _T) of object;
-     TNotifiers          = {$IFDEF FPC}specialize{$ENDIF} TLapeList<TNotifyProcOfObject>;
-   var protected
-     FNotifiers: TNotifiers;
-   public
-     constructor Create; reintroduce; virtual;
-     destructor Destroy; override;
+    TNotifyProcOfObject = procedure(Sender: _T) of object;
+    TNotifiers = {$IFDEF FPC}specialize{$ENDIF} TLapeList<TNotifyProcOfObject>;
+  protected
+    FNotifiers: TNotifiers;
+  public
+    constructor Create; reintroduce; virtual;
+    destructor Destroy; override;
 
-     procedure AddProc(const Proc: TNotifyProcOfObject); virtual;
-     procedure DeleteProc(const Proc: TNotifyProcOfObject); virtual;
+    procedure AddProc(const Proc: TNotifyProcOfObject); virtual;
+    procedure DeleteProc(const Proc: TNotifyProcOfObject); virtual;
 
-     procedure Notify(Sender: _T); virtual;
+    procedure Notify(Sender: _T); virtual;
   end;
 
   TLapeDeclaration = class;
   TLapeDeclarationClass = class of TLapeDeclaration;
   TLapeDeclArray = array of TLapeDeclaration;
 
+  // Abstract class
   TLapeDeclCollection = class(TLapeBaseClass)
+  protected
+    function getItem(Index: Integer): TLapeDeclaration; virtual; abstract;
+    function getCount: Integer; virtual; abstract;
+  public
+    procedure Clear; virtual; abstract;
+
+    procedure Add(Decl: TLapeDeclaration); virtual; abstract;
+    function Delete(Decl: TLapeDeclaration): Boolean; virtual; abstract;
+
+    function Get(Name: lpString; out Decl: TLapeDeclaration): Boolean; virtual; abstract;
+    function Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration): Boolean; virtual; abstract;
+    function GetByClass(AClass: TLapeDeclarationClass): TLapeDeclArray; virtual; abstract;
+
+    function IndexOf(Decl: TLapeDeclaration): Integer; virtual; abstract;
+    function Exists(Decl: TLapeDeclaration): Boolean; virtual; abstract;
+
+    function ExportToArray: TLapeDeclArray; virtual; abstract;
+
+    property Count: Integer read getCount;
+    property Items[Index: Integer]: TLapeDeclaration read getItem; default;
+  end;
+
+  TLapeDeclCollection_Dictionary = class(TLapeDeclCollection)
   protected const
-    MIN_SIZE        = 32; // Must be power of two
-    GROWTH_STRATEGY = 8;
+    MIN_SIZE        = 16; // Must be power of two !!
+    GROWTH_STRATEGY = 8;  // ..
   protected type
     THashBucket  = {$IFDEF FPC}specialize{$ENDIF} TLapeList<TLapeDeclaration>;
     THashBuckets = array of THashBucket;
   protected
     FBuckets: THashBuckets;
     FSize: UInt32;
-    FCount: UInt32;
+    FCount: Integer;
     FNamedCount: Integer;
-    FInitialSize: Integer;
-    FGrowCheck: Boolean;
 
-    procedure NameChanged(Decl: TLapeDeclaration);
+    procedure NameChanged(Decl: TLapeDeclaration); virtual;
 
-    function _Delete(Hash: UInt32; Decl: TLapeDeclaration): Boolean;
-    procedure _Add(Hash: UInt32; Decl: TLapeDeclaration);
-    procedure _Grow;
+    function _Delete(Hash: UInt32; Decl: TLapeDeclaration): Boolean; virtual;
+    procedure _Add(Hash: UInt32; Decl: TLapeDeclaration); virtual;
+    procedure _Grow; virtual;
 
-    function getBucket(Hash: UInt32): THashBucket; overload; {$IFDEF Lape_Inline}inline;{$ENDIF}
-    function getBucket(Key: lpString): THashBucket; overload; {$IFDEF Lape_Inline}inline;{$ENDIF}
-    function getItem(Index: Integer): TLapeDeclaration; {$IFDEF Lape_Inline}inline;{$ENDIF}
+    function getItem(Index: Integer): TLapeDeclaration; override;
+    function getCount: Integer; override;
   public
-    constructor Create(InitialSize: Int32 = 0); reintroduce; virtual;
     destructor Destroy; override;
 
-    procedure Clear; virtual;
+    procedure Clear; override;
 
-    procedure Add(Decl: TLapeDeclaration); virtual;
-    function Delete(Decl: TLapeDeclaration): Boolean; virtual;
+    procedure Add(Decl: TLapeDeclaration); override;
+    function Delete(Decl: TLapeDeclaration): Boolean; override;
 
-    function Get(Name: lpString; out Decl: TLapeDeclaration): Boolean; virtual; overload;
-    function Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration): Boolean; virtual; overload;
-    function GetAll(AClass: TLapeDeclarationClass): TLapeDeclArray; virtual;
+    function Get(Name: lpString; out Decl: TLapeDeclaration): Boolean; override;
+    function Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration): Boolean; override;
+    function GetByClass(AClass: TLapeDeclarationClass): TLapeDeclArray; override;
 
-    function Exists(Decl: TLapeDeclaration): Boolean; virtual;
-    function IndexOf(Decl: TLapeDeclaration): Integer; virtual; // Slow! Avoid using when possible.
+    function IndexOf(Decl: TLapeDeclaration): Integer; override;
+    function Exists(Decl: TLapeDeclaration): Boolean; override;
 
-    property Count: UInt32 read FCount;
-    property Item[Index: Integer]: TLapeDeclaration read getItem; default; // Slow! Avoid using when possible.
+    function ExportToArray: TLapeDeclArray; override;
+  end;
+
+  TLapeDeclCollection_List = class(TLapeDeclCollection)
+  protected type
+    TList = {$IFDEF FPC}specialize{$ENDIF} TLapeList<TLapeDeclaration>;
+  protected
+    FList: TList;
+
+    function getItem(Index: Integer): TLapeDeclaration; override;
+    function getCount: Integer; override;
+  public
+    constructor Create(Sorted: Boolean); reintroduce; virtual;
+    destructor Destroy; override;
+
+    procedure Clear; override;
+
+    procedure Add(Decl: TLapeDeclaration); override;
+    function Delete(Decl: TLapeDeclaration): Boolean; override;
+
+    function Get(Name: lpString; out Decl: TLapeDeclaration): Boolean; override;
+    function Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration): Boolean; override;
+    function GetByClass(AClass: TLapeDeclarationClass): TLapeDeclArray; override;
+
+    function IndexOf(Decl: TLapeDeclaration): Integer; override;
+    function Exists(Decl: TLapeDeclaration): Boolean; override;
+
+    function ExportToArray: TLapeDeclArray; override;
   end;
 
   TLapeDeclarationList = class(TLapeBaseClass)
@@ -516,27 +566,30 @@ type
     Parent: TLapeDeclarationList;
     FreeDecls: Boolean;
 
-    constructor Create(AList: TLapeDeclCollection; ManageDeclarations: Boolean = True; InitialSize: Int32 = 0); reintroduce; virtual;
+    constructor Create(AList: TLapeDeclCollection; ManageDeclarations: Boolean = True); reintroduce; virtual;
     destructor Destroy; override;
 
-    function HasParent: Boolean;
+    function HasParent: Boolean; virtual;
     procedure Clear; virtual;
     procedure ClearSubDeclarations; virtual;
 
-    procedure addDeclaration(d: TLapeDeclaration); virtual;
-    function HasSubDeclaration(AName: lpString; CheckParent: TInitBool): Boolean; overload; virtual;
-    function HasSubDeclaration(ADecl: TLapeDeclaration; CheckParent: TInitBool): Boolean; overload; virtual;
+    procedure addDeclaration(Decl: TLapeDeclaration); virtual;
+    function HasSubDeclaration(Name: lpString; CheckParent: TInitBool): Boolean; overload; virtual;
+    function HasSubDeclaration(Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean; overload; virtual;
 
-    function IndexOf(d: TLapeDeclaration): Integer; virtual; // Slow! Avoid using if possible.
-    procedure Delete(d: TLapeDeclaration; DoFree: Boolean = False); overload; virtual;
+    function IndexOf(Decl: TLapeDeclaration): Integer; virtual;
+
+    procedure Delete(Decl: TLapeDeclaration; DoFree: Boolean = False); overload; virtual;
     procedure Delete(AClass: TLapeDeclarationClass; DoFree: Boolean = False); overload; virtual;
 
-    function Get(AName: lpString; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean; overload;
-    function Get(AName: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean; overload;
-    function GetAll(AClass: TLapeDeclarationClass; CheckParent: TInitBool): TLapeDeclArray;
+    function Get(Name: lpString; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean; overload; virtual;
+    function Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean; overload; virtual;
+    function GetByClass(AClass: TLapeDeclarationClass; CheckParent: TInitBool): TLapeDeclArray; virtual;
+
+    function ExportToArray: TLapeDeclArray; virtual;
 
     property Count: Integer read getCount;
-    property Items[Index: Integer]: TLapeDeclaration read getItem; default; // Slow! Avoid using if possible.
+    property Items[Index: Integer]: TLapeDeclaration read getItem; default;
     property ItemCount: Integer read getItemCount;
   end;
 
@@ -710,8 +763,8 @@ var
 const
   Lape_EmptyHash: UInt32 = $811C9DC5;
 
-function LapeCase(constref Str: lpString): lpString; {$IFDEF Lape_Inline}inline;{$ENDIF}
-function LapeHash(constref Str: lpString): UInt32; {$IFDEF Lape_Inline}inline;{$ENDIF}
+function LapeCase(const Str: lpString): lpString; {$IFDEF Lape_Inline}inline;{$ENDIF}
+function LapeHash(const Str: lpString): UInt32; {$IFDEF Lape_Inline}inline;{$ENDIF}
 function LapeTypeToString(Token: ELapeBaseType): lpString; {$IFDEF Lape_Inline}inline;{$ENDIF}
 function LapeOperatorToString(Token: EOperator): lpString; {$IFDEF Lape_Inline}inline;{$ENDIF}
 
@@ -756,7 +809,7 @@ uses
   {$IFDEF Lape_NeedAnsiStringsUnit}AnsiStrings,{$ENDIF}
   lpmessages;
 
-function LapeCase(constref Str: lpString): lpString;
+function LapeCase(const Str: lpString): lpString;
 begin
   {$IFDEF Lape_CaseSensitive}
   Result := Str;
@@ -765,16 +818,22 @@ begin
   {$ENDIF}
 end;
 
-// Fowler–Noll–Vo hash
-function LapeHash(constref Str: lpString): UInt32;
+// Fowler–Noll–Vo + extra shuffle
+function LapeHash(const Str: lpString): UInt32;
 var
-  i: Integer;
+  i, Len: Integer;
 begin
   {$UNDEF REDO_Q}{$IFOPT Q+}{$Q-}{$DEFINE REDO_Q}{$ENDIF}
   {$UNDEF REDO_R}{$IFOPT R+}{$R-}{$DEFINE REDO_R}{$ENDIF}
   Result := Lape_EmptyHash;
-  for i := 1 to Length(Str) do
-    Result := (Result xor Ord(Str[i])) * $1000193;
+
+  Len := Length(Str);
+  if (Len > 0) then
+  begin
+    for i := 1 to Len do
+      Result := (Result xor Ord(Str[i])) * $1000193;
+    Result := (Result xor Len) * $5BD1E995; // Extra shuffle
+  end;
   {$IFDEF REDO_Q}{$Q+}{$ENDIF}
   {$IFDEF REDO_R}{$R+}{$ENDIF}
 end;
@@ -1139,305 +1198,6 @@ begin
     Move(Arr[Index], Arr[Index + 1], (Hi - Index) * SizeOf(UInt64));
     Arr[Index] := Item;
   end;
-end;
-
-procedure TLapeUniqueDictionary.setValue(Key: lpString; Value: _T);
-var
-  Bucket: UInt32;
-begin
-  Bucket := LapeHash(UpperCase(Key)) and FSize;
-  if (FArr[Bucket].Name <> '') then
-    LapeExceptionFmt(lpeDuplicateDeclaration, [Key]);
-
-  FArr[Bucket].Name  := Key;
-  FArr[Bucket].Value := Value;
-end;
-
-function TLapeUniqueDictionary.getValue(Key: lpString): _T;
-begin
-  with FArr[LapeHash(UpperCase(Key)) and FSize] do
-    if SameText(Name, Key) then
-      Result := Value
-    else
-      Result := InvalidVal;
-end;
-
-constructor TLapeUniqueDictionary.Create(InvalidValue: _T; Size: Integer);
-begin
-  inherited Create();
-
-  // must be power of two
-  FSize := 16;
-  while (FSize < Size) do
-   FSize := FSize * 2;
-
-  FSize := Size - 1;
-  SetLength(FArr, Size);
-
-  InvalidVal := InvalidValue;
-end;
-
-procedure TLapeDeclCollection.NameChanged(Decl: TLapeDeclaration);
-begin
-  Assert(Decl <> nil);
-
-  _Delete(Decl.FNameHashPrevious, Decl);
-  _Add(Decl.FNameHash, Decl);
-end;
-
-function TLapeDeclCollection._Delete(Hash: UInt32; Decl: TLapeDeclaration): Boolean;
-begin
-  Assert(Decl <> nil);
-
-  Decl.FNameChangeNotifier.DeleteProc(@NameChanged);
-
-  if FCount > 0 then
-  begin
-    Result := getBucket(Hash).DeleteItem(Decl) <> nil;
-
-    if Result then
-    begin
-      Dec(FCount);
-      if (Decl.FName <> '') then
-        Dec(FNamedCount);
-    end;
-  end else
-    Result := False;
-end;
-
-procedure TLapeDeclCollection._Add(Hash: UInt32; Decl: TLapeDeclaration);
-begin
-  Assert(Decl <> nil);
-
-  if (FSize = 0) or (FGrowCheck and (FNamedCount > (FSize div 2))) then
-    _Grow();
-
-  with getBucket(Hash) do
-    Add(Decl);
-
-  Inc(FCount);
-  if (Decl.FName <> '') then
-    Inc(FNamedCount);
-
-  Decl.FNameChangeNotifier.AddProc(@NameChanged);
-end;
-
-procedure TLapeDeclCollection._Grow;
-var
-  i, j: Integer;
-  OldBuckets: THashBuckets;
-begin
-  OldBuckets := FBuckets;
-
-  FNamedCount := 0;
-  FCount := 0;
-
-  if (FSize = 0) then
-    FSize := MIN_SIZE - 1
-  else
-    FSize := (FSize + 1) * GROWTH_STRATEGY;
-
-  SetLength(FBuckets, 0);
-  SetLength(FBuckets, FSize + 1);
-
-  for i := 0 to FSize do
-    FBuckets[i] := THashBucket.Create(nil, dupAccept, True);
-
-  try
-    FGrowCheck := False;
-
-    for i := 0 to High(OldBuckets) do
-    begin
-      for j := 0 to OldBuckets[i].Count - 1 do
-        Add(OldBuckets[i][j]);
-
-      OldBuckets[i].Free();
-    end;
-  finally
-    FGrowCheck := True;
-  end;
-end;
-
-function TLapeDeclCollection.getBucket(Hash: UInt32): THashBucket;
-begin
-  Assert(FSize > 0);
-
-  Result := FBuckets[Hash and FSize];
-end;
-
-function TLapeDeclCollection.getBucket(Key: lpString): THashBucket;
-begin
-  Assert(FSize > 0);
-
-  Result := FBuckets[LapeHash(Key) and FSize];
-end;
-
-function TLapeDeclCollection.Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration): Boolean;
-var
-  HashBucket: THashBucket;
-  i: Integer;
-begin
-  if FCount > 0 then
-  begin
-    Name := LapeCase(Name);
-    HashBucket := getBucket(Name);
-
-    for i := 0 to HashBucket.Count - 1 do
-      if (HashBucket[i].FNameLapeCase = Name) and (HashBucket[i] is AClass) then
-      begin
-        Decl := HashBucket[i];
-
-        Result := True;
-        Exit;
-      end;
-  end;
-
-  Result := False;
-end;
-
-function TLapeDeclCollection.GetAll(AClass: TLapeDeclarationClass): TLapeDeclArray;
-var
-  i, j, c: Integer;
-begin
-  SetLength(Result, FCount);
-
-  if FCount > 0 then
-  begin
-    c := 0;
-    for i := 0 to FSize do
-      for j := 0 to FBuckets[i].Count - 1 do
-        if FBuckets[i][j] is AClass then
-        begin
-          Result[c] := FBuckets[i][j];
-
-          Inc(c);
-        end;
-
-    SetLength(Result, c);
-  end;
-end;
-
-procedure TLapeDeclCollection.Clear;
-var
-  i: Integer;
-begin
-  if (FCount > 0) then
-    for i := 0 to FSize do
-      FBuckets[i].Free();
-
-  FNamedCount := 0;
-  FCount := 0;
-  FSize := 0;
-end;
-
-function TLapeDeclCollection.getItem(Index: Integer): TLapeDeclaration;
-var
-  i,j,c: Integer;
-begin
-  if (Index >= 0) and (Index < FCount) then
-  begin
-    c := 0;
-    for i:=0 to FSize do
-    begin
-      if (c+FBuckets[i].Count >= Index) then
-      begin
-        for j:=0 to FBuckets[i].Count-1 do
-        begin
-          if (c+j = Index) then
-            Exit(FBuckets[i][j]);
-        end;
-      end;
-
-      Inc(c, FBuckets[i].Count);
-    end;
-  end;
-
-  Result := nil;
-end;
-
-constructor TLapeDeclCollection.Create(InitialSize: Int32);
-begin
-  inherited Create();
-
-  FGrowCheck := True;
-
-  if (InitialSize = 0) then
-    InitialSize := MIN_SIZE;
-
-  // must be power of two
-  FInitialSize := InitialSize;
-  while (FInitialSize < InitialSize) do
-    FInitialSize := FInitialSize * 2;
-end;
-
-destructor TLapeDeclCollection.Destroy;
-begin
-  Clear();
-
-  inherited;
-end;
-
-procedure TLapeDeclCollection.Add(Decl: TLapeDeclaration);
-begin
-  _Add(Decl.FNameHash, Decl);
-end;
-
-function TLapeDeclCollection.IndexOf(Decl: TLapeDeclaration): Integer;
-var
-  i: Integer;
-  Bucket: THashBucket;
-begin
-  if (Decl = nil) or (FCount = 0) then
-    Exit(-1);
-
-  Bucket := getBucket(Decl.FNameHash);
-
-  Result := Bucket.IndexOf(Decl);
-  if (Result > -1) then
-  begin
-    for i := 0 to FSize do
-    begin
-      if (FBuckets[i] = Bucket) then
-        Exit;
-
-      Inc(Result, FBuckets[i].Count);
-    end;
-  end
-end;
-
-function TLapeDeclCollection.Exists(Decl: TLapeDeclaration): Boolean;
-begin
-  if (FCount = 0) then
-    Exit(False);
-
-  Result := getBucket(Decl.FNameHash).ExistsItem(Decl);
-end;
-
-function TLapeDeclCollection.Get(Name: lpString; out Decl: TLapeDeclaration): Boolean;
-var
-  Bucket: THashBucket;
-  i: Integer;
-begin
-  if (FCount > 0) then
-  begin
-    Name := LapeCase(Name);
-    Bucket := GetBucket(Name);
-
-    for i := 0 to Bucket.Count - 1 do
-      if (Bucket[i].FNameLapeCase = Name) then
-      begin
-        Decl := Bucket[i];
-
-        Exit(True);
-      end;
-  end;
-
-  Result := False;
-end;
-
-function TLapeDeclCollection.Delete(Decl: TLapeDeclaration): Boolean;
-begin
-  Result := _Delete(Decl.FNameHash, Decl);
 end;
 
 function TLapeBaseClass._AddRef: Integer; {$IFDEF Interface_CDecl}cdecl{$ELSE}stdcall{$ENDIF};
@@ -2194,6 +1954,56 @@ begin
   Result.Items := FItems.ExportToArray;
 end;
 
+procedure TLapeUniqueDictionary{$IFNDEF FPC}<_T>{$ENDIF}.setValue(Key: lpString; Value: _T);
+var
+  Bucket: UInt32;
+begin
+  Key := LowerCase(Key);
+  Bucket := LapeHash(Key) and FSize;
+  if (FArr[Bucket].Name <> '') then
+    LapeExceptionFmt(lpeDuplicateHashBucket, [FArr[Bucket].Name, Key]);
+
+  FArr[Bucket].Name  := Key;
+  FArr[Bucket].Value := Value;
+
+  if (Length(Key) < FMinLength) then FMinLength := Length(Key);
+  if (Length(Key) > FMaxLength) then FMaxLength := Length(Key);
+end;
+
+function TLapeUniqueDictionary{$IFNDEF FPC}<_T>{$ENDIF}.getValue(Key: lpString): _T;
+var
+  Len: Integer;
+begin
+  Len := Length(Key);
+  if (Len >= FMinLength) and (Len <= FMaxLength) then
+  begin
+    Key := LowerCase(Key);
+    with FArr[LapeHash(Key) and FSize] do
+      if (Name = Key) then
+        Exit(Value);
+  end;
+
+  Result := InvalidVal;
+end;
+
+constructor TLapeUniqueDictionary{$IFNDEF FPC}<_T>{$ENDIF}.Create(InvalidValue: _T; Size: Integer);
+begin
+  inherited Create();
+
+  FMinLength := $FFFFFF;
+  FMaxLength := 0;
+
+  // must be power of two
+  FSize := 16;
+  while (FSize < Size) do
+    FSize := FSize * 2;
+
+  FSize := Size - 1;
+  SetLength(FArr, Size);
+
+  InvalidVal := InvalidValue;
+end;
+
 constructor TLapeNotifier{$IFNDEF FPC}<_T>{$ENDIF}.Create;
 begin
   inherited;
@@ -2214,10 +2024,8 @@ begin
 end;
 
 procedure TLapeNotifier{$IFNDEF FPC}<_T>{$ENDIF}.DeleteProc(const Proc: TNotifyProc);
-var
-  p: TNotifyProc;
 begin
-  p := FNotifiers.DeleteItem(Proc); //Assign to p to work around Delphi compiler bug
+  FNotifiers.DeleteItem(Proc);
 end;
 
 procedure TLapeNotifier{$IFNDEF FPC}<_T>{$ENDIF}.Notify(Sender: _T);
@@ -2252,10 +2060,8 @@ begin
 end;
 
 procedure TLapeNotifierOfObject{$IFNDEF FPC}<_T>{$ENDIF}.DeleteProc(const Proc: TNotifyProcOfObject);
-var
-  p: TNotifyProcOfObject;
 begin
-  p := FNotifiers.DeleteItem(Proc); //Assign to p to work around Delphi compiler bug
+  FNotifiers.DeleteItem(Proc);
 end;
 
 procedure TLapeNotifierOfObject{$IFNDEF FPC}<_T>{$ENDIF}.Notify(Sender: _T);
@@ -2270,14 +2076,342 @@ begin
   end;
 end;
 
-constructor TLapeDeclarationList.Create(AList: TLapeDeclCollection; ManageDeclarations: Boolean; InitialSize: Int32);
+procedure TLapeDeclCollection_Dictionary.NameChanged(Decl: TLapeDeclaration);
+begin
+  Assert(Decl <> nil);
+
+  _Delete(Decl.FNameHashPrevious, Decl);
+  _Add(Decl.FNameHash, Decl);
+end;
+
+function TLapeDeclCollection_Dictionary._Delete(Hash: UInt32; Decl: TLapeDeclaration): Boolean;
+begin
+  Assert(Decl <> nil);
+
+  Result := (FCount > 0) and (FBuckets[Hash and FSize].DeleteItem(Decl) <> nil);
+  if Result then
+  begin
+    Dec(FCount);
+    if (Decl.FName <> '') then
+      Dec(FNamedCount);
+  end;
+
+  Decl.FNameChangeNotifier.DeleteProc(@NameChanged);
+end;
+
+procedure TLapeDeclCollection_Dictionary._Add(Hash: UInt32; Decl: TLapeDeclaration);
+begin
+  Assert(Decl <> nil);
+
+  if (FSize = 0) or (FNamedCount > (FSize div 2)) then
+    _Grow();
+
+  with FBuckets[Hash and FSize] do
+    Add(Decl);
+
+  Inc(FCount);
+  if (Decl.FName <> '') then
+    Inc(FNamedCount);
+
+  Decl.FNameChangeNotifier.AddProc(@NameChanged);
+end;
+
+procedure TLapeDeclCollection_Dictionary._Grow;
+var
+  i, j: Integer;
+  NewBuckets: THashBuckets;
+  Decl: TLapeDeclaration;
+begin
+  if (FSize = 0) then
+  begin
+    FSize := MIN_SIZE - 1;
+
+    SetLength(FBuckets, FSize + 1);
+    for i := 0 to FSize do
+      FBuckets[i] := THashBucket.Create(nil, dupAccept, True);
+  end else
+  begin
+    FSize := (FSize + 1) * GROWTH_STRATEGY - 1;
+
+    SetLength(NewBuckets, FSize + 1);
+    for i := 0 to FSize do
+      NewBuckets[i] := THashBucket.Create(nil, dupAccept, True);
+
+    for i := 0 to High(FBuckets) do
+    begin
+      for j := 0 to FBuckets[i].Count - 1 do
+      begin
+        Decl := FBuckets[i][j];
+        with NewBuckets[Decl.FNameHash and FSize] do
+          Add(Decl);
+      end;
+
+      FBuckets[i].Free();
+    end;
+
+    FBuckets := NewBuckets;
+  end;
+end;
+
+function TLapeDeclCollection_Dictionary.getItem(Index: Integer): TLapeDeclaration;
+begin
+  Result := nil;
+
+  LapeExceptionFmt(lpeInvalidDictionaryOperation, ['getItem']);
+end;
+
+function TLapeDeclCollection_Dictionary.getCount: Integer;
+begin
+  Result := FCount;
+end;
+
+destructor TLapeDeclCollection_Dictionary.Destroy;
+begin
+  Clear();
+
+  inherited;
+end;
+
+procedure TLapeDeclCollection_Dictionary.Clear;
+var
+  i: Integer;
+begin
+  if (FCount > 0) then
+    for i := 0 to FSize do
+      FBuckets[i].Free();
+
+  FNamedCount := 0;
+  FCount := 0;
+  FSize := 0;
+end;
+
+procedure TLapeDeclCollection_Dictionary.Add(Decl: TLapeDeclaration);
+begin
+  Assert(Decl <> nil);
+
+  _Add(Decl.FNameHash, Decl);
+end;
+
+function TLapeDeclCollection_Dictionary.Delete(Decl: TLapeDeclaration): Boolean;
+begin
+  Result := _Delete(Decl.FNameHash, Decl);
+end;
+
+function TLapeDeclCollection_Dictionary.Get(Name: lpString; out Decl: TLapeDeclaration): Boolean;
+var
+  Bucket: THashBucket;
+  i: Integer;
+begin
+  if (FCount > 0) then
+  begin
+    Bucket := FBuckets[LapeHash(Name) and FSize];
+
+    for i := 0 to Bucket.Count - 1 do
+      if (Bucket[i].FNameLapeCase = Name) then
+      begin
+        Decl := Bucket[i];
+
+        Result := True;
+        Exit;
+      end;
+  end;
+
+  Result := False;
+end;
+
+function TLapeDeclCollection_Dictionary.Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration): Boolean;
+var
+  Bucket: THashBucket;
+  i: Integer;
+begin
+  if (FCount > 0) then
+  begin
+    Bucket := FBuckets[LapeHash(Name) and FSize];
+
+    for i := 0 to Bucket.Count - 1 do
+      if (Bucket[i].FNameLapeCase = Name) and (Bucket[i] is AClass) then
+      begin
+        Decl := Bucket[i];
+
+        Result := True;
+        Exit;
+      end;
+  end;
+
+  Result := False;
+end;
+
+function TLapeDeclCollection_Dictionary.GetByClass(AClass: TLapeDeclarationClass ): TLapeDeclArray;
+var
+  Current: Integer;
+  Decl: TLapeDeclaration;
+begin
+  SetLength(Result, FCount);
+
+  if (FCount > 0) then
+  begin
+    Current := 0;
+
+    for Decl in ExportToArray() do
+      if (Decl is AClass) then
+      begin
+        Result[Current] := Decl;
+        Inc(Current);
+      end;
+
+    SetLength(Result, Current);
+  end;
+end;
+
+function TLapeDeclCollection_Dictionary.IndexOf(Decl: TLapeDeclaration): Integer;
+begin
+  Result := -1;
+
+  LapeExceptionFmt(lpeInvalidDictionaryOperation, ['IndexOf']);
+end;
+
+function TLapeDeclCollection_Dictionary.Exists(Decl: TLapeDeclaration): Boolean;
+begin
+  Result := (FCount > 0) and FBuckets[Decl.FNameHash and FSize].ExistsItem(Decl);
+end;
+
+function TLapeDeclCollection_Dictionary.ExportToArray: TLapeDeclArray;
+var
+  i: Integer;
+  Current: Integer;
+  Bucket: THashBucket;
+begin
+  SetLength(Result, FCount);
+  if (FCount = 0) then
+    Exit;
+
+  Current := 0;
+  for i := 0 to FSize do
+  begin
+    Bucket := FBuckets[i];
+    if (Bucket.Count = 0) then
+      Continue;
+
+    Move(Bucket.FItems[0], Result[Current], Bucket.Count * SizeOf(TLapeDeclaration));
+    Inc(Current, Bucket.Count);
+  end;
+end;
+
+function TLapeDeclCollection_List.getItem(Index: Integer): TLapeDeclaration;
+begin
+  Result := FList[Index];
+end;
+
+function TLapeDeclCollection_List.getCount: Integer;
+begin
+  Result := FList.Count;
+end;
+
+constructor TLapeDeclCollection_List.Create(Sorted: Boolean);
+begin
+  inherited Create;
+
+  FList := TList.Create(nil, dupAccept, Sorted);
+end;
+
+destructor TLapeDeclCollection_List.Destroy;
+begin
+  FList.Free();
+
+  inherited Destroy;
+end;
+
+procedure TLapeDeclCollection_List.Clear;
+begin
+  FList.Clear();
+end;
+
+procedure TLapeDeclCollection_List.Add(Decl: TLapeDeclaration);
+begin
+  FList.Add(Decl);
+end;
+
+function TLapeDeclCollection_List.Delete(Decl: TLapeDeclaration): Boolean;
+begin
+  Result := FList.DeleteItem(Decl) <> nil;
+end;
+
+function TLapeDeclCollection_List.Get(Name: lpString; out Decl: TLapeDeclaration): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to FList.Count - 1 do
+    if (FList[i].FNameLapeCase = Name) then
+    begin
+      Decl := FList[i];
+
+      Result := True;
+      Exit;
+    end;
+
+  Result := False;
+end;
+
+function TLapeDeclCollection_List.Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration): Boolean;
+var
+  i: Integer;
+begin
+  for i := 0 to FList.Count - 1 do
+    if (FList[i].FNameLapeCase = Name) and (FList[i] is AClass) then
+    begin
+      Decl := FList[i];
+
+      Result := True;
+      Exit;
+    end;
+
+  Result := False;
+end;
+
+function TLapeDeclCollection_List.GetByClass(AClass: TLapeDeclarationClass): TLapeDeclArray;
+var
+  Current: Integer;
+  Decl: TLapeDeclaration;
+begin
+  SetLength(Result, FList.Count);
+
+  if (FList.Count > 0) then
+  begin
+    Current := 0;
+
+    for Decl in ExportToArray() do
+      if (Decl is AClass) then
+      begin
+        Result[Current] := Decl;
+        Inc(Current);
+      end;
+
+    SetLength(Result, Current);
+  end;
+end;
+
+function TLapeDeclCollection_List.IndexOf(Decl: TLapeDeclaration): Integer;
+begin
+  Result := FList.IndexOf(Decl);
+end;
+
+function TLapeDeclCollection_List.Exists(Decl: TLapeDeclaration): Boolean;
+begin
+  Result := FList.ExistsItem(Decl);
+end;
+
+function TLapeDeclCollection_List.ExportToArray: TLapeDeclArray;
+begin
+  Result := FList.ExportToArray();
+end;
+
+constructor TLapeDeclarationList.Create(AList: TLapeDeclCollection; ManageDeclarations: Boolean);
 begin
   inherited Create();
 
   if (AList = nil) then
-    AList := TLapeDeclCollection.Create(InitialSize);
+    AList := TLapeDeclCollection_Dictionary.Create();
 
-  Parent := nil;
   FList := AList;
   FreeDecls := ManageDeclarations;
 end;
@@ -2287,6 +2421,7 @@ begin
   Clear();
   if (FList <> nil) then
     FList.Free();
+
   inherited;
 end;
 
@@ -2310,89 +2445,97 @@ begin
     Result := 0;
 end;
 
+function TLapeDeclarationList.IndexOf(Decl: TLapeDeclaration): Integer;
+begin
+  if (FList <> nil) then
+    Result := FList.IndexOf(Decl)
+  else
+    Result := -1;
+end;
+
 function TLapeDeclarationList.getItem(Index: Integer): TLapeDeclaration;
 begin
   if (FList <> nil) then
-    Result := FList[Index];
+    Result := FList[Index]
+  else
+    Result := nil;
 end;
 
 procedure TLapeDeclarationList.Clear;
 var
-  i: Integer;
+  Decl: TLapeDeclaration;
 begin
   if (FList <> nil) then
   begin
     if FreeDecls then
     begin
       ClearSubDeclarations();
-      for i := FList.Count - 1 downto 0 do
-        if (FList[i] <> nil) then
-        begin
-          FList[i].FList := nil;
-          FList[i].Free();
-        end;
+
+      for Decl in FList.ExportToArray() do
+      begin
+        Decl.FList := nil;
+        Decl.Free();
+      end;
     end;
+
     FList.Clear();
   end;
 end;
 
 procedure TLapeDeclarationList.ClearSubDeclarations;
 var
-  ClassItems: TLapeDeclArray;
+  Decls: TLapeDeclArray;
   i: Integer;
 begin
-  ClassItems := GetAll(TLapeManagingDeclaration, bFalse);
-  for i := High(ClassItems) downto 0 do
-    TLapeManagingDeclaration(ClassItems[i]).ClearSubDeclarations();
+  Decls := GetByClass(TLapeManagingDeclaration, bFalse);
+  for i := High(Decls) downto 0 do
+    TLapeManagingDeclaration(Decls[i]).ClearSubDeclarations();
 end;
 
-procedure TLapeDeclarationList.addDeclaration(d: TLapeDeclaration);
+procedure TLapeDeclarationList.addDeclaration(Decl: TLapeDeclaration);
 begin
-  if (FList <> nil) and (d <> nil) and (not HasSubDeclaration(d, bFalse)) then
+  if (FList <> nil) and (Decl <> nil) and (not HasSubDeclaration(Decl, bFalse)) then
   begin
-    FList.Add(d);
-    if (d.DeclarationList <> nil) then
-      d.DeclarationList := Self
+    FList.Add(Decl);
+    if (Decl.DeclarationList <> nil) then
+      Decl.DeclarationList := Self
     else
-      d.FList := Self;
+      Decl.FList := Self;
   end;
 end;
 
-function TLapeDeclarationList.HasSubDeclaration(AName: lpString; CheckParent: TInitBool): Boolean;
+function TLapeDeclarationList.HasSubDeclaration(Name: lpString; CheckParent: TInitBool): Boolean;
 var
   Decl: TLapeDeclaration;
 begin
-  Result := Get(AName, Decl, CheckParent);;
+  Result := Get(Name, Decl, CheckParent);;
 end;
 
-function TLapeDeclarationList.HasSubDeclaration(ADecl: TLapeDeclaration; CheckParent: TInitBool): Boolean;
+function TLapeDeclarationList.HasSubDeclaration(Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean;
 begin
   if (FList = nil) then
     Exit(False);
 
-  Result := FList.Exists(ADecl);
+  Result := FList.Exists(Decl);
   if (not Result) and HasParent() then
     if (CheckParent = bUnknown) then
-      Result := Parent.HasSubDeclaration(ADecl, bFalse)
+      Result := Parent.HasSubDeclaration(Decl, bFalse)
     else if (CheckParent = bTrue) then
-      Result := Parent.HasSubDeclaration(ADecl, bTrue);
+      Result := Parent.HasSubDeclaration(Decl, bTrue);
 end;
 
-function TLapeDeclarationList.IndexOf(d: TLapeDeclaration): Integer;
+function TLapeDeclarationList.ExportToArray: TLapeDeclArray;
 begin
-  if FList <> nil then
-    Result := FList.IndexOf(d)
-  else
-    Result := -1;
+  Result := FList.ExportToArray;
 end;
 
-procedure TLapeDeclarationList.Delete(d: TLapeDeclaration; DoFree: Boolean = False);
+procedure TLapeDeclarationList.Delete(Decl: TLapeDeclaration; DoFree: Boolean);
 begin
-  if (FList <> nil) and FList.Delete(d) then
+  if (FList <> nil) and FList.Delete(Decl) then
     if DoFree then
-      d.Free()
+      Decl.Free()
     else
-      d.FList := nil;
+      Decl.FList := nil;
 end;
 
 procedure TLapeDeclarationList.Delete(AClass: TLapeDeclarationClass; DoFree: Boolean = False);
@@ -2400,51 +2543,53 @@ var
   ClassItems: TLapeDeclArray;
   i: Integer;
 begin
-  ClassItems := GetAll(AClass, bFalse);
+  ClassItems := GetByClass(AClass, bFalse);
   for i := High(ClassItems) downto 0 do
     Delete(ClassItems[i], DoFree);
 end;
 
-function TLapeDeclarationList.Get(AName: lpString; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean;
+function TLapeDeclarationList.Get(Name: lpString; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean;
 begin
   Result := False;
 
+  Name := LapeCase(Name);
   if (FList <> nil) then
-    Result := FList.Get(AName, Decl);
+    Result := FList.Get(Name, Decl);
 
   if (not Result) and HasParent() then
     if (CheckParent = bUnknown) then
-      Result := Parent.Get(AName, Decl, bFalse)
+      Result := Parent.Get(Name, Decl, bFalse)
     else if (CheckParent = bTrue) then
-      Result := Parent.Get(AName, Decl, bTrue);
+      Result := Parent.Get(Name, Decl, bTrue);
 end;
 
-function TLapeDeclarationList.Get(AName: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean;
+function TLapeDeclarationList.Get(Name: lpString; AClass: TLapeDeclarationClass; out Decl: TLapeDeclaration; CheckParent: TInitBool): Boolean;
 begin
   Result := False;
 
+  Name := LapeCase(Name);
   if (FList <> nil) then
-    Result := FList.Get(AName, AClass, Decl);
+    Result := FList.Get(Name, AClass, Decl);
 
   if (not Result) and HasParent() then
     if (CheckParent = bUnknown) then
-      Result := Parent.Get(AName, AClass, Decl, bFalse)
+      Result := Parent.Get(Name, AClass, Decl, bFalse)
     else if (CheckParent = bTrue) then
-      Result := Parent.Get(AName, AClass, Decl, bTrue);
+      Result := Parent.Get(Name, AClass, Decl, bTrue);
 end;
 
-function TLapeDeclarationList.GetAll(AClass: TLapeDeclarationClass; CheckParent: TInitBool): TLapeDeclArray;
+function TLapeDeclarationList.GetByClass(AClass: TLapeDeclarationClass; CheckParent: TInitBool): TLapeDeclArray;
 begin
   Result := nil;
 
   if (FList <> nil) then
-    Result := FList.GetAll(AClass);
+    Result := FList.GetByClass(AClass);
 
   if (Result = nil) and HasParent() then
     if (CheckParent = bUnknown) then
-      Result := Parent.GetAll(AClass, bFalse)
+      Result := Parent.GetByClass(AClass, bFalse)
     else if (CheckParent = bTrue) then
-      Result := Parent.GetAll(AClass, bTrue);
+      Result := Parent.GetByClass(AClass, bTrue);
 end;
 
 function TLapeDeclaration.getDocPos: TDocPos;

--- a/lputils.pas
+++ b/lputils.pas
@@ -128,7 +128,6 @@ procedure TraverseGlobals(Compiler: TLapeCompilerBase; Callback: TTraverseCallba
   end;
 
 var
-  i: Integer;
   n: lpString;
   Decl: TLapeDeclaration;
 begin
@@ -144,13 +143,12 @@ begin
       Decls := Compiler.GlobalDeclarations;
     end;
 
-  for i := 0 to Decls.Count - 1 do
+  for Decl in Decls.ExportToArray() do
   begin
-    Decl := Decls[i];
     try
       if (Decl.Name = '') then
         if (Decl is TLapeGlobalVar) and (TLapeGlobalVar(Decl).VarType is TLapeType_Method) then
-          n := BaseName + '[' + lpString(IntToStr(i)) + ']'
+          n := BaseName + '[' + lpString(IntToStr(Decls.IndexOf(Decl))) + ']'
         else
           Continue
       else if (BaseName <> '') then

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -263,7 +263,7 @@ type
     function NewGlobalVarStr(Str: AnsiString; AName: lpString = ''; ADocPos: PDocPos = nil): TLapeGlobalVar; overload; virtual;
     function NewGlobalVarStr(Str: UnicodeString; AName: lpString = ''; ADocPos: PDocPos = nil): TLapeGlobalVar; overload; virtual;
 
-    function addSubDeclaration(ADecl: TLapeDeclaration): Integer; override;
+    procedure addSubDeclaration(ADecl: TLapeDeclaration); override;
     function CanHaveChild: Boolean; virtual;
     function IsOrdinal(OrPointer: Boolean = False): Boolean; virtual;
 
@@ -452,7 +452,7 @@ type
     constructor Create(ACompiler: TLapeCompilerBase; AName: lpString = ''; ADocPos: PDocPos = nil); reintroduce; virtual;
     function CreateCopy(DeepCopy: Boolean = False): TLapeType; override;
 
-    function addSubDeclaration(ADecl: TLapeDeclaration): Integer; override;
+    procedure addSubDeclaration(ADecl: TLapeDeclaration); override;
     procedure addMethod(AMethod: TLapeGlobalVar; DoOverride: Boolean = False); virtual;
     function overrideMethod(AMethod: TLapeGlobalVar): TLapeGlobalVar; virtual;
 
@@ -548,7 +548,7 @@ type
     function hasDeclaration(Decl: TLapeDeclaration; CheckParent: TInitBool; CheckWith: Boolean): Boolean; overload; virtual;
 
     function getTempVar(VarType: TLapeType; Lock: Integer = 1): TLapeStackTempVar; virtual;
-    function addDeclaration(Decl: TLapeDeclaration): Integer; override;
+    procedure addDeclaration(Decl: TLapeDeclaration); override;
     function addVar(StackVar: TLapeStackVar): TLapeStackVar; overload; virtual;
     function addVar(VarType: TLapeType; Name: lpString = ''): TLapeStackVar; overload; virtual;
     function addVar(ParType: ELapeParameterType; VarType: TLapeType; Name: lpString = ''): TLapeStackVar; overload; virtual;
@@ -580,14 +580,14 @@ type
     //constructor Create(AList: TLapeDeclarationList; AOwner: TLapeStackInfo = nil); reintroduce; overload; virtual;
     constructor Create(AList: TLapeManagingDeclaration; AOwner: TLapeStackInfo = nil); reintroduce; overload; virtual;
 
-    function addDeclaration(Decl: TLapeDeclaration): Integer; override;
+    procedure addDeclaration(Decl: TLapeDeclaration); override;
     function addVar(StackVar: TLapeStackVar): TLapeStackVar; override;
     property ManagingList: TLapeManagingDeclaration read FManagingList;
   end;
 
   TLapeEmptyStack = class(TLapeStackInfo)
   public
-    function addDeclaration(Decl: TLapeDeclaration): Integer; override;
+    procedure addDeclaration(Decl: TLapeDeclaration); override;
   end;
 
   TLapeCodeEmitter = class(TLapeCodeEmitterBase)
@@ -750,7 +750,7 @@ begin
   case op of
     op_AssignDiv:
       if (typ.BaseType in LapeRealTypes) then
-        Result := op_divide
+        Result := op_Divide
       else
         Result := op_DIV;
     op_AssignMinus: Result := op_Minus;
@@ -1211,7 +1211,7 @@ begin
   if (AParent is TLapeStackInheritedVar) then
   begin
     Create(TLapeStackInheritedVar(AParent).Parent, AStack, AList);
-    FName := '!' + FName;
+    Name := '!' + Name;
     Exit;
   end
   else if AParent.isConstant then
@@ -1516,14 +1516,14 @@ begin
   LapeException(lpeImpossible);
 end;
 
-function TLapeType.addSubDeclaration(ADecl: TLapeDeclaration): Integer;
+procedure TLapeType.addSubDeclaration(ADecl: TLapeDeclaration);
 begin
   if (ADecl.Name <> '') then
     if (not (ADecl is TLapeGlobalVar))  then
       LapeException(lpeImpossible)
     else if HasChild(ADecl.Name) then
       LapeExceptionFmt(lpeDuplicateDeclaration, [ADecl.Name]);
-  Result := inherited;
+  inherited;
 end;
 
 function TLapeType.CanHaveChild: Boolean;
@@ -1537,22 +1537,11 @@ begin
 end;
 
 function TLapeType.HasChild(AName: lpString): Boolean;
-var
-  DotName: TLapeGlobalVar;
 begin
   if (not CanHaveChild()) or (FCompiler = nil) then
     Exit(False);
 
-  Result := HasSubDeclaration(AName, bTrue);
-  if (not Result) then
-  begin
-    DotName := FCompiler.getBaseType(ltString).NewGlobalVarStr(AName);
-    try
-      Result := EvalRes(op_Dot, DotName) <> nil;
-    finally
-      DotName.Free();
-    end;
-  end;
+  Result := HasSubDeclaration(AName, bTrue) or (EvalRes(op_Dot, Compiler.getConstant(AName)) <> nil);
 end;
 
 function TLapeType.HasChild(ADecl: TLapeDeclaration): Boolean;
@@ -1562,13 +1551,12 @@ end;
 
 function TLapeType.HasConstantChild(Left: TLapeGlobalVar; AName: lpString): Boolean;
 var
-  Decls: TLapeDeclArray;
+  Decl: TLapeDeclaration;
 begin
-  Decls := FManagedDecls.getByClassAndName(AName, TLapeGlobalVar, bTrue);
-  if (Length(Decls) <= 0) then
-    Result := HasChild(AName)
-  else with TLapeGlobalVar(Decls[0]) do
-    Result := Readable and (BaseType = ltImportedMethod);
+  if FManagedDecls.Get(AName, TLapeGlobalVar, Decl, bTrue) then
+    Result := TLapeGlobalVar(Decl).Readable and (TLapeGlobalVar(Decl).BaseType = ltImportedMethod)
+  else
+    Result := HasChild(AName);
 end;
 
 function TLapeType.EvalRes(Op: EOperator; Right: TLapeType = nil; Flags: ELapeEvalFlags = []): TLapeType;
@@ -1606,7 +1594,7 @@ end;
 
 function TLapeType.EvalRes(Op: EOperator; Right: TLapeGlobalVar; Flags: ELapeEvalFlags = []): TLapeType;
 var
-  d: TLapeDeclArray;
+  Decl: TLapeDeclaration;
 begin
   if (Right = nil) then
     Result := EvalRes(Op, TLapeType(nil), Flags)
@@ -1614,14 +1602,13 @@ begin
   begin
     Result := EvalRes(Op, Right.VarType, Flags);
 
-    if (Result = nil) and (op = op_Dot) and CanHaveChild() and ValidFieldName(Right) then
+    if (Result = nil) and (op = op_Dot) and CanHaveChild() and ValidFieldName(Right) and
+       FManagedDecls.Get(PlpString(Right.Ptr)^, Decl, bTrue) then
     begin
-      d := FManagedDecls.getByName(PlpString(Right.Ptr)^, bTrue);
-      if (Length(d) = 1) then
-        if (d[0] is TLapeType) then
-          Result := TLapeType(d[0])
-        else if (d[0] is TLapeVar) then
-          Result := TLapeVar(d[0]).VarType;
+      if (Decl is TLapeType) then
+        Result := TLapeType(Decl)
+      else if (Decl is TLapeVar) then
+        Result := TLapeVar(Decl).VarType;
     end;
   end;
 
@@ -1686,39 +1673,40 @@ function TLapeType.EvalConst(Op: EOperator; Left, Right: TLapeGlobalVar; Flags: 
 
   function EvalDot(Field: lpString): TLapeGlobalVar;
   var
-    d: TLapeDeclArray;
+    Decl: TLapeDeclaration;
     Res: TLapeGlobalVar;
   begin
+    Result := nil;
     if (Left = nil) or (not HasSubDeclaration(Field, bTrue)) then
       LapeExceptionFmt(lpeUnknownDeclaration, [Field]);
 
-    d := FManagedDecls.getByName(Field, bTrue);
-    Assert(Length(d) = 1);
-
-    if (d[0] is TLapeType) then
-      d[0] := FCompiler.getTypeVar(TLapeType(d[0]));
-    Result := d[0] as TLapeGlobalVar;
-
-    if (Result <> nil) and MethodOfObject(Result.VarType) and (not Result.Readable) and (not Result.Writeable) then
+    if FManagedDecls.Get(Field, Decl, bTrue) then
     begin
-      if (not (lefInvoking in Flags)) and (not Left.Writeable) then
-        if InheritsFrom(TLapeType_Type) then
-          Exit()
-        else
-          LapeException(lpeVariableExpected);
+      if (Decl is TLapeType) then
+        Decl := FCompiler.getTypeVar(TLapeType(Decl));
+      Result := Decl as TLapeGlobalVar;
 
-      Res := FCompiler.getGlobalType('TMethod').NewGlobalVarP(nil);
-      Res.VarType := Result.VarType;
-
-      with TMethod(Res.Ptr^) do
+      if MethodOfObject(Result.VarType) and (not Result.Readable) and (not Result.Writeable) then
       begin
-        if (Result.Ptr <> nil) then
-          Code := PPointer(Result.Ptr)^;
-        Data := Left.Ptr;
-      end;
+        if (not (lefInvoking in Flags)) and (not Left.Writeable) then
+          if InheritsFrom(TLapeType_Type) then
+            Exit()
+          else
+            LapeException(lpeVariableExpected);
 
-      Result := Res;
-      Result.Readable := Left.Writeable;
+        Res := FCompiler.getGlobalType('TMethod').NewGlobalVarP(nil);
+        Res.VarType := Result.VarType;
+
+        with TMethod(Res.Ptr^) do
+        begin
+          if (Result.Ptr <> nil) then
+            Code := PPointer(Result.Ptr)^;
+          Data := Left.Ptr;
+        end;
+
+        Result := Res;
+        Result.Readable := Left.Writeable;
+      end;
     end;
   end;
 
@@ -1870,32 +1858,34 @@ function TLapeType.Eval(Op: EOperator; var Dest: TResVar; Left, Right: TResVar; 
 
   function EvalDot(Field: lpString): TResVar;
   var
-    d: TLapeDeclArray;
+    Decl: TLapeDeclaration;
     Res: TResVar;
   begin
+    Result := NullResVar;
+    Dest := NullResVar;
+
     if (not HasSubDeclaration(Field, bTrue)) then
       LapeExceptionFmt(lpeUnknownDeclaration, [Field]);
 
-    d := FManagedDecls.getByName(Field, bTrue);
-    Assert(Length(d) = 1);
-
-    if (d[0] is TLapeType) then
-      d[0] := FCompiler.getTypeVar(TLapeType(d[0]));
-
-    Dest := NullResVar;
-    Result := _ResVar.New(d[0] as TLapeGlobalVar);
-
-    if MethodOfObject(Result.VarType) and (not Result.Readable) and (not Result.Writeable) then
+    if FManagedDecls.Get(Field, Decl, bTrue) then
     begin
-      Res := _ResVar.New(FCompiler.getTempVar(FCompiler.getGlobalType('TMethod')));
-      Res.VarType := Result.VarType;
+      if (Decl is TLapeType) then
+        Decl := FCompiler.getTypeVar(TLapeType(Decl));
 
-      if (not (lefInvoking in Flags)) and (not Left.Writeable) then
-        LapeException(lpeVariableExpected);
+      Result := _ResVar.New(Decl as TLapeGlobalVar);
 
-      FCompiler.Emitter._Eval(getEvalProc(op_Dot, ltUnknown, ltPointer), Res, Result, Left.IncLock(), Offset, Pos);
-      Result := Res;
-      Result.Readable := Left.Writeable;
+      if MethodOfObject(Result.VarType) and (not Result.Readable) and (not Result.Writeable) then
+      begin
+        Res := _ResVar.New(FCompiler.getTempVar(FCompiler.getGlobalType('TMethod')));
+        Res.VarType := Result.VarType;
+
+        if (not (lefInvoking in Flags)) and (not Left.Writeable) then
+          LapeException(lpeVariableExpected);
+
+        FCompiler.Emitter._Eval(getEvalProc(op_Dot, ltUnknown, ltPointer), Res, Result, Left.IncLock(), Offset, Pos);
+        Result := Res;
+        Result.Readable := Left.Writeable;
+      end;
     end;
   end;
 
@@ -2947,7 +2937,6 @@ begin
   FHiddenSelf := bUnknown;
   OnFunctionNotFound := nil;
   NeedFullMatch := False;
-  FManagedDecls.Sorted := False;
 end;
 
 function TLapeType_OverloadedMethod.CreateCopy(DeepCopy: Boolean = False): TLapeType;
@@ -2961,9 +2950,8 @@ begin
   TLapeType_OverloadedMethod(Result).FOfObject := FOfObject;
 end;
 
-function TLapeType_OverloadedMethod.addSubDeclaration(ADecl: TLapeDeclaration): Integer;
+procedure TLapeType_OverloadedMethod.addSubDeclaration(ADecl: TLapeDeclaration);
 begin
-  Result := -1;
   LapeException(lpeImpossible);
 end;
 
@@ -3036,7 +3024,7 @@ begin
     if TLapeType_Method(OldMethod.VarType).EqualParams(AMethod.VarType as TLapeType_Method) then
     begin
       Result := OldMethod;
-      FManagedDecls.Delete(i);
+      FManagedDecls.Delete(FManagedDecls[i]);
       Break;
     end;
   end;
@@ -3496,19 +3484,13 @@ end;
 function TLapeStackInfo.getDeclaration(Name: lpString; CheckParent: TInitBool; CheckWith: Boolean): TLapeDeclaration;
 var
   i: Integer;
-  Declarations: TLapeDeclArray;
 begin
   if CheckWith then
     for i := FWithStack.Count - 1 downto 0 do
       if (FWithStack[i].WithType <> nil) and FWithStack[i].WithType.hasChild(Name) then
         Exit(TLapeWithDeclaration.Create(FWithStack[i]));
 
-  Declarations := getByName(Name, CheckParent);
-  if (Length(Declarations) > 1) then
-    LapeExceptionFmt(lpeDuplicateDeclaration, [Name])
-  else if (Length(Declarations) > 0) and (Declarations[0] <> nil) then
-    Result := Declarations[0]
-  else
+  if not Get(Name, Result, CheckParent) then
     Result := nil;
 end;
 
@@ -3560,15 +3542,15 @@ begin
   end;
 end;
 
-function TLapeStackInfo.addDeclaration(Decl: TLapeDeclaration): Integer;
+procedure TLapeStackInfo.addDeclaration(Decl: TLapeDeclaration);
 begin
-  if (Decl = nil) then
-    Result := -1
-  else if FList.ExistsItem(Decl) or ((Decl.Name <> '') and hasDeclaration(Decl.Name, bTrue, True)) or
-         (Pos(LapeCase('|'+Decl.Name+'|'), LapeReservedLocals) > 0)
-  then
-    LapeExceptionFmt(lpeDuplicateDeclaration, [Decl.Name]);
-  Result := FList.Add(Decl);
+  if (Decl <> nil) then
+  begin
+    if FList.Exists(Decl) or ((Decl.Name <> '') and hasDeclaration(Decl.Name, bTrue, True)) or (Pos(LapeCase('|'+Decl.Name+'|'), LapeReservedLocals) > 0) then
+      LapeExceptionFmt(lpeDuplicateDeclaration, [Decl.Name]);
+
+    FList.Add(Decl);
+  end;
 end;
 
 function TLapeStackInfo.addVar(StackVar: TLapeStackVar): TLapeStackVar;
@@ -3648,9 +3630,9 @@ begin
   FManagingList := AList;
 end;
 
-function TLapeDeclStack.addDeclaration(Decl: TLapeDeclaration): Integer;
+procedure TLapeDeclStack.addDeclaration(Decl: TLapeDeclaration);
 begin
-  Result := FManagingList.addSubDeclaration(Decl);
+  FManagingList.addSubDeclaration(Decl);
 end;
 
 function TLapeDeclStack.addVar(StackVar: TLapeStackVar): TLapeStackVar;
@@ -3659,9 +3641,8 @@ begin
   LapeException(lpeImpossible);
 end;
 
-function TLapeEmptyStack.addDeclaration(Decl: TLapeDeclaration): Integer;
+procedure TLapeEmptyStack.addDeclaration(Decl: TLapeDeclaration);
 begin
-  Result := -1;
   LapeException(lpeImpossible);
 end;
 
@@ -4517,33 +4498,24 @@ end;
 
 function TLapeCompilerBase.getGlobalVar(AName: lpString): TLapeGlobalVar;
 var
-  Declarations: TLapeDeclArray;
+  Decl: TLapeDeclaration;
 begin
-  Declarations := GlobalDeclarations.getByClassAndName(AName, TLapeGlobalVar, bTrue);
-  if (Length(Declarations) > 1) then
-    LapeExceptionFmt(lpeDuplicateDeclaration, [AName])
-  else if (Length(Declarations) > 0) and (Declarations[0] <> nil) then
-    Result := Declarations[0] as TLapeGlobalVar
-  else
-    Result := nil;
+  Result := nil;
+  if FGlobalDeclarations.Get(AName, Decl, bFalse) and (Decl is TLapeGlobalVar) then
+    Result := TLapeGlobalVar(Decl);
 end;
 
 function TLapeCompilerBase.getGlobalType(AName: lpString): TLapeType;
 var
-  Declarations: TLapeDeclArray;
+  Decl: TLapeDeclaration;
 begin
-  Declarations := GlobalDeclarations.getByClassAndName(AName, TLapeType, bTrue);
-  if (Length(Declarations) > 1) then
-    LapeExceptionFmt(lpeDuplicateDeclaration, [AName])
-  else if (Length(Declarations) > 0) and (Declarations[0] <> nil) then
-    Result := Declarations[0] as TLapeType
-  else
-    Result := nil;
+  Result := nil;
+  if FGlobalDeclarations.Get(AName, Decl, bFalse) and (Decl is TLapeType) then
+    Result := TLapeType(Decl);
 end;
 
 function TLapeCompilerBase.getDeclaration(AName: lpString; AStackInfo: TLapeStackInfo; LocalOnly: Boolean = False; CheckWith: Boolean = True): TLapeDeclaration;
 var
-  Declarations: TLapeDeclArray;
   Stack: TLapeStackInfo;
 begin
   Stack := AStackInfo;
@@ -4566,12 +4538,7 @@ begin
     Stack := Stack.Owner;
   end;
 
-  Declarations := GlobalDeclarations.getByName(AName, bTrue);
-  if (Length(Declarations) > 1) then
-    LapeExceptionFmt(lpeDuplicateDeclaration, [AName])
-  else if (Length(Declarations) > 0) and (Declarations[0] <> nil) then
-    Result := Declarations[0]
-  else
+  if not FGlobalDeclarations.Get(AName, Result, bTrue) then
     Result := getBaseType(AName);
 end;
 
@@ -4581,6 +4548,8 @@ begin
 end;
 
 function TLapeCompilerBase.hasDeclaration(AName: lpString; AStackInfo: TLapeStackInfo; LocalOnly: Boolean = False; CheckWith: Boolean = True): Boolean;
+var
+  Decl: TLapeDeclaration;
 begin
   if (AStackInfo <> nil) then
   begin
@@ -4593,10 +4562,7 @@ begin
       Exit;
   end;
 
-  if (Length(GlobalDeclarations.getByName(AName, bTrue)) > 0) then
-    Result := True
-  else
-    Result := getBaseType(AName) <> nil;
+  Result := FGlobalDeclarations.Get(AName, Decl, bFalse) or (getBaseType(AName) <> nil);
 end;
 
 function TLapeCompilerBase.hasDeclaration(AName: lpString; LocalOnly: Boolean = False; CheckWith: Boolean = True): Boolean;

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -1068,8 +1068,8 @@ begin
   if UseCompiler and (FCompiler <> nil) then
   begin
     Counter := FCompiler.getTempVar(ltSizeInt, BigLock);
-    LowIndex := FCompiler.getConstant(FRange.Lo);
-    HighIndex := FCompiler.getConstant(FRange.Hi);
+    LowIndex := FCompiler.getConstant(FRange.Lo, Counter.BaseType);
+    HighIndex := FCompiler.getConstant(FRange.Hi, Counter.BaseType);
     IndexVar := Counter.VarType.Eval(op_Assign, IndexVar, _ResVar.New(Counter), _ResVar.New(LowIndex), [], Offset, Pos);
     LoopOffset := Offset;
     FCompiler.FinalizeVar(Eval(op_Index, tmpVar, AVar, IndexVar, [], Offset, Pos), Offset, Pos);

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -195,7 +195,7 @@ begin
   if (FCompiler = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(0, ltSizeInt, False, True);
+    Result := FCompiler.getConstant(0, ltSizeInt);
 end;
 
 function TLapeType_DynArray.VarHi(AVar: Pointer = nil): TLapeGlobalVar;
@@ -203,7 +203,7 @@ begin
   if (FCompiler = nil) or (AVar = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(High(PCodeArray(AVar)^), ltSizeInt, False, True);
+    Result := FCompiler.getConstant(High(PCodeArray(AVar)^), ltSizeInt);
 end;
 
 procedure TLapeType_DynArray.VarSetLength(var AVar: Pointer; ALen: SizeInt);
@@ -837,7 +837,7 @@ begin
   if (FCompiler = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(FRange.Lo, ltSizeInt, False, True);
+    Result := FCompiler.getConstant(FRange.Lo, ltSizeInt);
 end;
 
 function TLapeType_StaticArray.VarHi(AVar: Pointer = nil): TLapeGlobalVar;
@@ -845,7 +845,7 @@ begin
   if (FCompiler = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(FRange.Hi, ltSizeInt, False, True);
+    Result := FCompiler.getConstant(FRange.Hi, ltSizeInt);
 end;
 
 function TLapeType_StaticArray.CreateCopy(DeepCopy: Boolean = False): TLapeType;
@@ -1004,7 +1004,7 @@ begin
         else
           wasConstant := False;
 
-        IndexHigh := FCompiler.getConstant(Size, ltSizeInt, False, True);
+        IndexHigh := FCompiler.getConstant(Size, ltSizeInt);
         tmpVar := Compiler.getTempStackVar(ltPointer);
         FCompiler.Emitter._Eval(getEvalProc(op_Addr, ltUnknown, ltUnknown), tmpVar, Right, NullResVar, Offset, Pos);
         if wasConstant then
@@ -1035,12 +1035,12 @@ begin
         wasConstant := False;
 
       CounterVar := FCompiler.getTempVar(ltSizeInt, BigLock);
-      IndexLow := FCompiler.getConstant(FRange.Lo, CounterVar.VarType.BaseType, False, True);
-      IndexHigh := FCompiler.getConstant(FRange.Hi, CounterVar.VarType.BaseType, False, True);
+      IndexLow := FCompiler.getConstant(FRange.Lo, CounterVar.VarType.BaseType);
+      IndexHigh := FCompiler.getConstant(FRange.Hi, CounterVar.VarType.BaseType);
       LeftVar := CounterVar.VarType.Eval(op_Assign, LeftVar, _ResVar.New(CounterVar), _ResVar.New(IndexLow), [], Offset, Pos);
       LoopOffset := Offset;
       FPType.Eval(op_Assign, tmpVar, Eval(op_Index, tmpVar, Left, LeftVar, [], Offset, Pos), Right.VarType.Eval(op_Index, tmpVar, Right, LeftVar, [], Offset, Pos), [], Offset, Pos);
-      CounterVar.VarType.Eval(op_Assign, tmpVar, LeftVar, CounterVar.VarType.Eval(op_Plus, tmpVar, LeftVar, _ResVar.New(FCompiler.getConstant(1, CounterVar.VarType.BaseType, False, True)), [], Offset, Pos), [], Offset, Pos);
+      CounterVar.VarType.Eval(op_Assign, tmpVar, LeftVar, CounterVar.VarType.Eval(op_Plus, tmpVar, LeftVar, _ResVar.New(FCompiler.getConstant(1, CounterVar.VarType.BaseType)), [], Offset, Pos), [], Offset, Pos);
       FCompiler.Emitter._JmpRIf(LoopOffset - Offset, CounterVar.VarType.Eval(op_cmp_LessThanOrEqual, tmpVar, LeftVar, _ResVar.New(IndexHigh), [], Offset, Pos), Offset, Pos);
       LeftVar.Spill(BigLock);
 
@@ -1068,12 +1068,12 @@ begin
   if UseCompiler and (FCompiler <> nil) then
   begin
     Counter := FCompiler.getTempVar(ltSizeInt, BigLock);
-    LowIndex := FCompiler.addManagedVar(Counter.VarType.NewGlobalVarStr(lpString(IntToStr(FRange.Lo))));
-    HighIndex := FCompiler.addManagedVar(Counter.VarType.NewGlobalVarStr(lpString(IntToStr(FRange.Hi))));
+    LowIndex := FCompiler.getConstant(FRange.Lo);
+    HighIndex := FCompiler.getConstant(FRange.Hi);
     IndexVar := Counter.VarType.Eval(op_Assign, IndexVar, _ResVar.New(Counter), _ResVar.New(LowIndex), [], Offset, Pos);
     LoopOffset := Offset;
     FCompiler.FinalizeVar(Eval(op_Index, tmpVar, AVar, IndexVar, [], Offset, Pos), Offset, Pos);
-    Counter.VarType.Eval(op_Assign, tmpVar, IndexVar, Counter.VarType.Eval(op_Plus, tmpVar, IndexVar, _ResVar.New(FCompiler.addManagedVar(Counter.VarType.NewGlobalVarStr('1'))), [], Offset, Pos), [], Offset, Pos);
+    Counter.VarType.Eval(op_Assign, tmpVar, IndexVar, Counter.VarType.Eval(op_Plus, tmpVar, IndexVar, _ResVar.New(FCompiler.getConstant(1)), [], Offset, Pos), [], Offset, Pos);
     FCompiler.Emitter._JmpRIf(LoopOffset - Offset, Counter.VarType.Eval(op_cmp_LessThanOrEqual, tmpVar, IndexVar, _ResVar.New(HighIndex), [], Offset, Pos), Offset, Pos);
     IndexVar.Spill(BigLock);
   end
@@ -1133,7 +1133,7 @@ begin
   if (FCompiler = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(1, ltSizeInt, False, True);
+    Result := FCompiler.getConstant(1, ltSizeInt);
 end;
 
 function TLapeType_String.VarHi(AVar: Pointer = nil): TLapeGlobalVar;
@@ -1141,7 +1141,7 @@ begin
   if (FCompiler = nil) or (AVar = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(Length(PString(AVar)^), ltSizeInt, False, True);
+    Result := FCompiler.getConstant(Length(PString(AVar)^), ltSizeInt);
 end;
 
 function TLapeType_String.NewGlobalVarStr(Str: AnsiString; AName: lpString = ''; ADocPos: PDocPos = nil): TLapeGlobalVar;
@@ -1259,15 +1259,15 @@ begin
   if (FCompiler = nil) then
     Result := nil
   else
-    Result := FCompiler.getConstant(1, ltUInt8, False, True);
+    Result := FCompiler.getConstant(1, ltUInt8);
 end;
 
 function TLapeType_ShortString.VarHi(AVar: Pointer = nil): TLapeGlobalVar;
 begin
-  if (FCompiler = nil) then
-    Result := FCompiler.getConstant(Length(PShortString(AVar)^), ltUInt8, False, True)
+  if (AVar <> nil) then
+    Result := FCompiler.getConstant(Length(PShortString(AVar)^), ltUInt8)
   else
-    Result := FCompiler.getConstant(FRange.Hi, ltUInt8, False, True);
+    Result := FCompiler.getConstant(FRange.Hi, ltUInt8);
 end;
 
 function TLapeType_ShortString.NewGlobalVarStr(Str: UnicodeString; AName: lpString = ''; ADocPos: PDocPos = nil): TLapeGlobalVar;

--- a/lpvartypes_ord.pas
+++ b/lpvartypes_ord.pas
@@ -412,14 +412,14 @@ end;
 function TLapeType_SubRange.VarLo(AVar: Pointer = nil): TLapeGlobalVar;
 begin
   if (FLo = nil) and (FCompiler <> nil) and IsOrdinal() then
-    FLo := FCompiler.addManagedVar(NewGlobalVarStr(lpString(IntToStr(Range.Lo)))) as TLapeGlobalVar;
+    FLo := FCompiler.addManagedDecl(NewGlobalVar(FRange.Lo)) as TLapeGlobalVar;
   Result := FLo;
 end;
 
 function TLapeType_SubRange.VarHi(AVar: Pointer = nil): TLapeGlobalVar;
 begin
   if (FHi = nil) and (FCompiler <> nil) and IsOrdinal() then
-    FHi := FCompiler.addManagedVar(NewGlobalVarStr(lpString(IntToStr(Range.Hi)))) as TLapeGlobalVar;
+    FHi := FCompiler.addManagedDecl(NewGlobalVar(FRange.Hi)) as TLapeGlobalVar;
   Result := FHi;
 end;
 

--- a/lpvartypes_ord.pas
+++ b/lpvartypes_ord.pas
@@ -626,7 +626,7 @@ begin
   if (Str <> '') and (AnsiChar(Str[1]) in ['-', '0'..'9']) then
     Result := NewGlobalVar(StrToInt64(string(Str)), AName, ADocPos)
   else
-    Result := NewGlobalVar(FMemberMap.IndexOf(Str), AName, ADocPos);
+    Result := NewGlobalVar(FMemberMap.IndexOf(string(Str)), AName, ADocPos);
 end;
 
 function TLapeType_Enum.EvalAsSubType(Op: EOperator; Right: TLapeType): Boolean;

--- a/lpvartypes_record.pas
+++ b/lpvartypes_record.pas
@@ -390,7 +390,7 @@ begin
       Result := Left.IncLock();
       Result.VarType :=FieldType;
       case Left.VarPos.MemPos of
-        mpMem: Result.VarPos.GlobalVar := TLapeGlobalVar(FCompiler.addManagedVar(Result.VarType.NewGlobalVarP(Pointer(PtrUInt(Left.VarPos.GlobalVar.Ptr) + Offset)), True));
+        mpMem: Result.VarPos.GlobalVar := TLapeGlobalVar(FCompiler.addManagedDecl(Result.VarType.NewGlobalVarP(Pointer(PtrUInt(Left.VarPos.GlobalVar.Ptr) + Offset))));
         mpVar,
         mpStack: Result.IncOffset(Offset);
         else LapeException(lpeImpossible);
@@ -410,7 +410,7 @@ begin
       end
       else
       begin
-        RightVar := _ResVar.New(FCompiler.getConstant(Size, ltSizeInt, False, True));
+        RightVar := _ResVar.New(FCompiler.getConstant(Size, ltSizeInt));
         tmpVar := Compiler.getTempStackVar(ltPointer);
         FCompiler.Emitter._Eval(getEvalProc(op_Addr, ltUnknown, ltUnknown), tmpVar, Right, NullResVar, Offset, @Self._DocPos);
         FCompiler.Emitter._Eval(getEvalProc(op_Addr, ltUnknown, ltUnknown), tmpVar, Left, NullResVar, Offset, @Self._DocPos);
@@ -461,7 +461,7 @@ begin
       begin
         Assert(op in [op_cmp_Equal, op_cmp_NotEqual]);
 
-        RightVar := _ResVar.New(FCompiler.getConstant(Size, ltSizeInt, False, True));
+        RightVar := _ResVar.New(FCompiler.getConstant(Size, ltSizeInt));
         tmpVar := Compiler.getTempStackVar(ltPointer);
         FCompiler.Emitter._Eval(getEvalProc(op_Addr, ltUnknown, ltUnknown), tmpVar, Left, NullResVar, Offset, @Self._DocPos);
         FCompiler.Emitter._Eval(getEvalProc(op_Addr, ltUnknown, ltUnknown), tmpVar, Right, NullResVar, Offset, @Self._DocPos);
@@ -527,7 +527,7 @@ begin
     case FieldVar.VarPos.MemPos of
       mpMem:
         if UseCompiler and (FCompiler <> nil) then
-          FieldVar.VarPos.GlobalVar := TLapeGlobalVar(FCompiler.addManagedVar(FieldVar.VarType.NewGlobalVarP(Pointer(PtrUInt(FieldVar.VarPos.GlobalVar.Ptr) + FFieldMap.ItemsI[i].Offset)), True))
+          FieldVar.VarPos.GlobalVar := TLapeGlobalVar(FCompiler.addManagedDecl(FieldVar.VarType.NewGlobalVarP(Pointer(PtrUInt(FieldVar.VarPos.GlobalVar.Ptr) + FFieldMap.ItemsI[i].Offset))))
         else
           FieldVar.VarPos.GlobalVar := FieldVar.VarType.NewGlobalVarP(Pointer(PtrUInt(FieldVar.VarPos.GlobalVar.Ptr) + FFieldMap.ItemsI[i].Offset));
       mpVar: FieldVar.IncOffset(FFieldMap.ItemsI[i].Offset);

--- a/lpvartypes_record.pas
+++ b/lpvartypes_record.pas
@@ -311,24 +311,18 @@ begin
     end
   else if (op = op_Assign) and (Right <> nil) and Right.HasType() and CompatibleWith(Right.VarType) then
   begin
-    LeftFieldName := nil;
-    RightFieldName := nil;
     LeftVar := nil;
     RightVar := nil;
 
     for i := 0 to FFieldMap.Count - 1 do
     try
-      LeftFieldName := FCompiler.getBaseType(ltString).NewGlobalVarStr(FFieldMap.Key[i]);
-      RightFieldName := FCompiler.getBaseType(ltString).NewGlobalVarStr(TLapeType_Record(Right.VarType).FieldMap.Key[i]);
+      LeftFieldName := FCompiler.getConstant(FFieldMap.Key[i]);
+      RightFieldName := FCompiler.getConstant(TLapeType_Record(Right.VarType).FieldMap.Key[i]);
 
       LeftVar := EvalConst(op_Dot, Left, LeftFieldName, []);
       RightVar := Right.VarType.EvalConst(op_Dot, Right, RightFieldName, []);
       LeftVar.VarType.EvalConst(op, LeftVar, RightVar, []);
     finally
-      if (LeftFieldName <> nil) then
-        FreeAndNil(LeftFieldName);
-      if (RightFieldName <> nil) then
-        FreeAndNil(RightFieldName);
       if (LeftVar <> nil) then
         FreeAndNil(LeftVar);
       if (RightVar <> nil) then
@@ -339,15 +333,13 @@ begin
   end
   else if (op in [op_cmp_Equal, op_cmp_NotEqual]) and (Right <> nil) and Right.HasType() and (EvalRes(op, Right, Flags) <> nil) then
   begin
-    LeftFieldName := nil;
-    RightFieldName := nil;
     LeftVar := nil;
     RightVar := nil;
 
     for i := 0 to FFieldMap.Count - 1 do
     try
-      LeftFieldName := FCompiler.getBaseType(ltString).NewGlobalVarStr(FFieldMap.Key[i]);
-      RightFieldName := FCompiler.getBaseType(ltString).NewGlobalVarStr(TLapeType_Record(Right.VarType).FieldMap.Key[i]);
+      LeftFieldName := FCompiler.getConstant(FFieldMap.Key[i]);
+      RightFieldName := FCompiler.getConstant(TLapeType_Record(Right.VarType).FieldMap.Key[i]);
 
       LeftVar := EvalConst(op_Dot, Left, LeftFieldName, []);
       RightVar := Right.VarType.EvalConst(op_Dot, Right, RightFieldName, []);
@@ -358,10 +350,6 @@ begin
       if (Result.AsInteger <> Ord(False)) xor (op = op_cmp_Equal) then
         Exit;
     finally
-      if (LeftFieldName <> nil) then
-        FreeAndNil(LeftFieldName);
-      if (RightFieldName <> nil) then
-        FreeAndNil(RightFieldName);
       if (LeftVar <> nil) then
         FreeAndNil(LeftVar);
       if (RightVar <> nil) then

--- a/main.pas
+++ b/main.pas
@@ -128,7 +128,7 @@ begin
 
       try
         if Disassemble then
-          DisassembleCode(Compiler.Emitter.Code, CombineDeclArray(Compiler.ManagedDeclarations.getByClass(TLapeGlobalVar, bTrue), Compiler.GlobalDeclarations.getByClass(TLapeGlobalVar, bTrue)));
+          DisassembleCode(Compiler.Emitter.Code, CombineDeclArray(Compiler.ManagedDeclarations.GetByClass(TLapeGlobalVar, bTrue), Compiler.GlobalDeclarations.GetByClass(TLapeGlobalVar, bTrue)));
 
         if Run then
         begin


### PR DESCRIPTION
Compiling SRL went from `450ms` to `280ms`.
I think the only other related optimization worth doing in the future would be not compiling method statement list if the method is never used. 

Changes:

`TLapeDeclCollection` is now an abstract class.

`TLapeDeclarationList` uses `TLapeDeclCollection_Dictionary` by default. There remains `TLapeDeclCollection_List` for when normal indexing is required which is currently only `TLapeType_OverloadedMethod`.

----

Added `TLapeUniqueDictionary` which is a dictionary where each bucket can only have one value. `TLapeCompiler.getBaseType(Name: lpString)` and `Lape_IsKeyword` now use this.

----

Optimized `TLapeCompiler.getConstant` and usage of it.
`TLapeParser.Identify` `Alpha()` no longer appends character by character. `getTokString` is now called once at the end.
Removed some compiling hints.