### PR TITLE
Fix #147

### DIFF
--- a/lptree.pas
+++ b/lptree.pas
@@ -1048,7 +1048,7 @@ begin
         LapeException(lpeInvalidCompareMethod, DocPos);
     end;
 
-    CompareVar.VarType := FCompiler.addManagedType(TLapeType_Method.Create(FCompiler, [nil, nil], [lptConstRef, lptConstRef], [TLapeGlobalVar(nil), TLapeGlobalVar(nil)], ResultType));
+    CompareVar.VarType := FCompiler.addManagedType(TLapeType_Method.Create(FCompiler, [TLapeType(nil), TLapeType(nil)], [lptConstRef, lptConstRef], [TLapeGlobalVar(nil), TLapeGlobalVar(nil)], ResultType));
   end;
 
   wasConstant := not ParamVar.Writeable;

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -608,26 +608,27 @@ begin
         'end;'
       , ['Left', 'Right'], [], [ALeft, ARight], Offset, Pos)}
 
-      with TLapeTree_If.Create(FCompiler, Pos) do
-      try
-        Condition := TLapeTree_Operator.Create(op_cmp_NotEqual, Self.FCompiler, Pos);
-        with TLapeTree_Operator(Condition) do
-        begin
-          Left := TLapeTree_ResVar.Create(ALeft.IncLock(), Condition);
-          Right := TLapeTree_ResVar.Create(ARight.IncLock(), Condition);
-        end;
+      if (tmpVar = nil) then // ALeft is initalized (issue #147)
+        with TLapeTree_If.Create(FCompiler, Pos) do
+        try
+          Condition := TLapeTree_Operator.Create(op_cmp_NotEqual, Self.FCompiler, Pos);
+          with TLapeTree_Operator(Condition) do
+          begin
+            Left := TLapeTree_ResVar.Create(ALeft.IncLock(), Condition);
+            Right := TLapeTree_ResVar.Create(ARight.IncLock(), Condition);
+          end;
 
-        Body := TLapeTree_InternalMethod_SetLength.Create(Condition);
-        with TLapeTree_InternalMethod_SetLength(Body) do
-        begin
-          addParam(TLapeTree_ResVar.Create(ALeft.IncLock(), Body));
-          addParam(TLapeTree_Integer.Create(0, Body));
-        end;
+          Body := TLapeTree_InternalMethod_SetLength.Create(Condition);
+          with TLapeTree_InternalMethod_SetLength(Body) do
+          begin
+            addParam(TLapeTree_ResVar.Create(ALeft.IncLock(), Body));
+            addParam(TLapeTree_Integer.Create(0, Body));
+          end;
 
-        Compile(Offset).Spill(1);
-      finally
-        Free();
-      end;
+          Compile(Offset).Spill(1);
+        finally
+          Free();
+        end;
 
       inherited;
     end

--- a/tests/Bugs/DynArrStackVar.lap
+++ b/tests/Bugs/DynArrStackVar.lap
@@ -1,0 +1,21 @@
+type
+  TCrash = record
+    A: array of Int32;
+    B: String;
+    C: String;
+  end;
+
+procedure test_crash_1(test: TCrash);
+begin
+end;
+
+procedure test_crash_2(const test: TCrash);
+begin
+end;
+
+var
+  crash: TCrash = [[1]];
+begin
+  test_crash_1(crash);
+  test_crash_2(crash);
+end.


### PR DESCRIPTION
If dynamic array is on the stack a new uninitialized var is created. This was then `SetLength(arr, 0)` on what is likely random memory.