### PR TITLE
Add SortWeighted

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -898,7 +898,8 @@ begin
     _LapeCopy +
     _LapeDelete +
     _LapeInsert +
-    _LapeSort,
+    _LapeSort +
+    _LapeSortWeighted,
     '!addDelayedCore'
   );
 
@@ -3508,6 +3509,9 @@ begin
 
   FInternalMethodMap['Sort'] := TLapeTree_InternalMethod_Sort;
   FInternalMethodMap['Sorted'] := TLapeTree_InternalMethod_Sorted;
+
+  FInternalMethodMap['SortWeighted'] := TLapeTree_InternalMethod_SortWeighted;
+  FInternalMethodMap['SortedWeighted'] := TLapeTree_InternalMethod_SortedWeighted;
 
   FInternalMethodMap['Ord'] := TLapeTree_InternalMethod_Ord;
   FInternalMethodMap['Succ'] := TLapeTree_InternalMethod_Succ;

--- a/lpeval.pas
+++ b/lpeval.pas
@@ -400,7 +400,7 @@ var
     '  Item: Pointer;'                                                                   + LineEnding +
     'begin'                                                                              + LineEnding +
     '  if (Compare = nil) then'                                                          + LineEnding +
-    '    raise "Compare function is nil";'                                               + LineEnding +
+    '    raise "Sort: Compare function is nil";'                                         + LineEnding +
     ''                                                                                   + LineEnding +
     '  Item := GetMem(ElSize);'                                                          + LineEnding +
     '  for I := 1 to Len - 1 do'                                                         + LineEnding +
@@ -413,6 +413,65 @@ var
     '      Dec(J);'                                                                      + LineEnding +
     '    end;'                                                                           + LineEnding +
     '    Move(Item^, A[(J+1) * ElSize]^, ElSize);'                                       + LineEnding +
+    '  end;'                                                                             + LineEnding +
+    '  FreeMem(Item);'                                                                   + LineEnding +
+    'end;';
+
+    _LapeSortWeighted: lpString =
+    'procedure _SortWeighted(A: Pointer; ElSize, Len: SizeInt;'                          + LineEnding +
+    '  Weights: ^Int64; WeightsLen: SizeInt); overload;'                                 + LineEnding +
+    'var'                                                                                + LineEnding +
+    '  I, J: Int32;'                                                                     + LineEnding +
+    '  Weight: Int64;'                                                                   + LineEnding +
+    '  Item: Pointer;'                                                                   + LineEnding +
+    'begin'                                                                              + LineEnding +
+    '  if (Len <> WeightsLen) then'                                                      + LineEnding +
+    '    raise Format("Sort: Array and weights lengths must be equal (%d, %d)",'         + LineEnding +
+    '                 [Len, WeightsLen]);'                                               + LineEnding +
+    ''                                                                                   + LineEnding +
+    '  Item := GetMem(ElSize);'                                                          + LineEnding +
+    '  for I := 1 to Len - 1 do'                                                         + LineEnding +
+    '  begin'                                                                            + LineEnding +
+    '    Move(A[I * ElSize]^, Item^, ElSize);'                                           + LineEnding +
+    '    Weight := Weights[I]^;'                                                         + LineEnding +
+    '    J := I - 1;'                                                                    + LineEnding +
+    '    while (J >= 0) and (Weights[J]^ > Weight) do'                                   + LineEnding +
+    '    begin'                                                                          + LineEnding +
+    '      Move(A[J * ElSize]^, A[(J+1) * ElSize]^, ElSize);'                            + LineEnding +
+    '      Weights[J + 1]^ := Weights[J]^;'                                              + LineEnding +
+    '      Dec(J);'                                                                      + LineEnding +
+    '    end;'                                                                           + LineEnding +
+    '    Move(Item^, A[(J+1) * ElSize]^, ElSize);'                                       + LineEnding +
+    '    Weights[J + 1]^ := Weight;'                                                     + LineEnding +
+    '  end;'                                                                             + LineEnding +
+    '  FreeMem(Item);'                                                                   + LineEnding +
+    'end;'                                                                               + LineEnding +
+    ''                                                                                   + LineEnding +
+    'procedure _SortWeightedF(A: Pointer; ElSize, Len: SizeInt;'                         + LineEnding +
+    '  Weights: ^Extended; WeightsLen: SizeInt); overload;'                              + LineEnding +
+    'var'                                                                                + LineEnding +
+    '  I, J: Int32;'                                                                     + LineEnding +
+    '  Weight: Extended;'                                                                + LineEnding +
+    '  Item: Pointer;'                                                                   + LineEnding +
+    'begin'                                                                              + LineEnding +
+    '  if (Len <> WeightsLen) then'                                                      + LineEnding +
+    '    raise Format("Sort: Array and weights lengths must be equal (%d, %d)",'         + LineEnding +
+    '                 [Len, WeightsLen]);'                                               + LineEnding +
+    ''                                                                                   + LineEnding +
+    '  Item := GetMem(ElSize);'                                                          + LineEnding +
+    '  for I := 1 to Len - 1 do'                                                         + LineEnding +
+    '  begin'                                                                            + LineEnding +
+    '    Move(A[I * ElSize]^, Item^, ElSize);'                                           + LineEnding +
+    '    Weight := Weights[I]^;'                                                         + LineEnding +
+    '    J := I - 1;'                                                                    + LineEnding +
+    '    while (J >= 0) and (Weights[J]^ > Weight) do'                                   + LineEnding +
+    '    begin'                                                                          + LineEnding +
+    '      Move(A[J * ElSize]^, A[(J+1) * ElSize]^, ElSize);'                            + LineEnding +
+    '      Weights[J + 1]^ := Weights[J]^;'                                              + LineEnding +
+    '      Dec(J);'                                                                      + LineEnding +
+    '    end;'                                                                           + LineEnding +
+    '    Move(Item^, A[(J+1) * ElSize]^, ElSize);'                                       + LineEnding +
+    '    Weights[J + 1]^ := Weight;'                                                     + LineEnding +
     '  end;'                                                                             + LineEnding +
     '  FreeMem(Item);'                                                                   + LineEnding +
     'end;';

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -59,6 +59,7 @@ const
   lpeExceptionInFile = '%s in file "%s"';
   lpeExpected = '%s expected';
   lpeExpectedArray = 'Array expected';
+  lpeExpectedArrayOfType = 'Array expected of type "%s"';
   lpeExpectedNormalMethod = 'Normal method expected';
   lpeExpectedOther = 'Found unexpected token "%s", expected "%s"';
   lpeExpressionExpected = 'Expression expected';

--- a/tests/System_SortWeighted.lap
+++ b/tests/System_SortWeighted.lap
@@ -1,0 +1,26 @@
+{$assertions on}
+
+function dist(fromX, fromY, toX, toY: Integer): Extended;
+begin
+  Result := Hypot(fromX-toX, fromY-toY);
+end;
+
+var
+  points: array of record x,y: Integer; end;
+  weights: array of Extended;
+  i: Integer;
+begin
+  points += [200,200];
+  points += [100,100];
+  points += [150,150];
+  points += [75, 75];
+  points += [80, 80];
+
+  for i:=0 to High(points) do
+    weights += dist(points[i].x, points[i].y, 100, 100);
+
+  SortWeighted(points, weights);
+
+  Assert(ToString(points) = '[{X = 100, Y = 100}, {X = 80, Y = 80}, {X = 75, Y = 75}, {X = 150, Y = 150}, {X = 200, Y = 200}]');
+  Assert(ToString(SortedWeighted(points, [Int64(4),Int64(3),Int64(2),Int64(1),Int64(0)])) = '[{X = 200, Y = 200}, {X = 150, Y = 150}, {X = 75, Y = 75}, {X = 80, Y = 80}, {X = 100, Y = 100}]');
+end.


### PR DESCRIPTION
`Sort` lacks the ability to provide any data to the compare callback. So i've added `SortWeighted`.
Example:
```pascal
function dist(fromX, fromY, toX, toY: Integer): Extended;
begin
  Result := Hypot(fromX-toX, fromY-toY);
end;

var
  points: array of record x,y: Integer; end;
  weights: array of Extended;
  i: Integer;
begin
  points += [200,200];
  points += [100,100];
  points += [150,150];
  points += [75, 75];
  points += [80, 80];

  for i:=0 to High(points) do
    weights += dist(points[i].x, points[i].y, 100, 100);

  SortWeighted(points, weights); // points are now sorted from 100,100
  ```
- `weights` must either be `array of Int64` or `array of Extended`
- `SortedWeighted` (which returns a copy) also added.
- `Sort` was also cleaned up.
  