### PR TITLE
Delphi fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ gmon.out
 __history/
 lib/
 backup/
+__recovery
+*.rsm

--- a/delphi/LapeTest.dpr
+++ b/delphi/LapeTest.dpr
@@ -1,0 +1,14 @@
+program LapeTest;
+
+uses
+  Vcl.Forms,
+  main in 'main.pas' {Form1};
+
+{$R *.res}
+
+begin
+  Application.Initialize;
+  Application.MainFormOnTaskbar := True;
+  Application.CreateForm(TForm1, Form1);
+  Application.Run;
+end.

--- a/delphi/LapeTest.dproj
+++ b/delphi/LapeTest.dproj
@@ -1,22 +1,16 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <ProjectGuid>{4AFF689A-14B8-4F54-9BA8-E98CB85BF94F}</ProjectGuid>
+        <ProjectGuid>{EC49DBBA-536E-4E38-8841-141C7FE65DEA}</ProjectGuid>
         <ProjectVersion>19.2</ProjectVersion>
-        <MainSource>LapeTest.dpr</MainSource>
-        <Config Condition="'$(Config)'==''">Debug</Config>
-        <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
-        <FrameworkType>None</FrameworkType>
+        <FrameworkType>VCL</FrameworkType>
         <Base>True</Base>
-        <Platform Condition="'$(Platform)'==''">OSX64</Platform>
-        <TargetedPlatforms>4099</TargetedPlatforms>
-        <AppType>Console</AppType>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <TargetedPlatforms>1</TargetedPlatforms>
+        <AppType>Application</AppType>
+        <MainSource>LapeTest.dpr</MainSource>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Base)'=='true') or '$(Base_OSX64)'!=''">
-        <Base_OSX64>true</Base_OSX64>
-        <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
@@ -29,195 +23,131 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
         <Cfg_1>true</Cfg_1>
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Cfg_1)'=='true') or '$(Cfg_1_OSX64)'!=''">
-        <Cfg_1_OSX64>true</Cfg_1_OSX64>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
         <CfgParent>Cfg_1</CfgParent>
         <Cfg_1>true</Cfg_1>
         <Base>true</Base>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
         <Cfg_2>true</Cfg_2>
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='OSX64' and '$(Cfg_2)'=='true') or '$(Cfg_2_OSX64)'!=''">
-        <Cfg_2_OSX64>true</Cfg_2_OSX64>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_2)'=='true') or '$(Cfg_2_Win32)'!=''">
+        <Cfg_2_Win32>true</Cfg_2_Win32>
         <CfgParent>Cfg_2</CfgParent>
         <Cfg_2>true</Cfg_2>
         <Base>true</Base>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base)'!=''">
-        <VerInfo_Locale>1043</VerInfo_Locale>
-        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
-        <DCC_UnitSearchPath>..\..\;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
-        <DCC_DependencyCheckOutputName>LapeTest.exe</DCC_DependencyCheckOutputName>
-        <DCC_ImageBase>00400000</DCC_ImageBase>
-        <DCC_Platform>x86</DCC_Platform>
+        <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
         <DCC_E>false</DCC_E>
         <DCC_N>false</DCC_N>
         <DCC_S>false</DCC_S>
         <DCC_F>false</DCC_F>
         <DCC_K>false</DCC_K>
-        <SanitizedProjectName>LapeTest</SanitizedProjectName>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
-        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_OSX64)'!=''">
-        <BT_BuildType>Debug</BT_BuildType>
-        <Base_OSX32>true</Base_OSX32>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
+        <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
+        <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
+        <SanitizedProjectName>LapeTest</SanitizedProjectName>
+        <VerInfo_Locale>2057</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <DCC_UnitSearchPath>../;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>DBXSqliteDriver;IndyIPCommon;RESTComponents;bindcompdbx;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;bindcompvclsmp;tethering;svnui;bindcompvclwinx;dsnapcon;FireDACADSDriver;FireDACMSAccDriver;fmxFireDAC;vclimg;FireDAC;vcltouch;vcldb;bindcompfmx;svn;FireDACSqliteDriver;FireDACPgDriver;inetdb;soaprtl;DbxCommonDriver;fmx;FireDACIBDriver;fmxdae;xmlrtl;soapmidas;vcledge;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;FireDACCommon;IndyIPClient;bindcompvcl;RESTBackendComponents;VCLRESTComponents;soapserver;dbxcds;VclSmp;adortl;vclie;bindengine;DBXMySQLDriver;CloudService;dsnapxml;FireDACMySQLDriver;dbrtl;IndyProtocols;inetdbxpress;FireDACCommonODBC;FireDACCommonDriver;inet;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
+        <Debugger_DebugSourcePath>../;$(Debugger_DebugSourcePath)</Debugger_DebugSourcePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
-        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
-        <VerInfo_Locale>1033</VerInfo_Locale>
+        <DCC_UsePackage>DBXSqliteDriver;IndyIPCommon;RESTComponents;bindcompdbx;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;bindcompvclsmp;tethering;bindcompvclwinx;dsnapcon;FireDACADSDriver;FireDACMSAccDriver;fmxFireDAC;vclimg;FireDAC;vcltouch;vcldb;bindcompfmx;FireDACSqliteDriver;FireDACPgDriver;inetdb;soaprtl;DbxCommonDriver;fmx;FireDACIBDriver;fmxdae;xmlrtl;soapmidas;vcledge;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;FireDACCommon;IndyIPClient;bindcompvcl;RESTBackendComponents;VCLRESTComponents;soapserver;dbxcds;VclSmp;adortl;vclie;bindengine;DBXMySQLDriver;CloudService;dsnapxml;FireDACMySQLDriver;dbrtl;IndyProtocols;inetdbxpress;FireDACCommonODBC;FireDACCommonDriver;inet;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
-        <DCC_AssertionsAtRuntime>false</DCC_AssertionsAtRuntime>
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugDCUs>true</DCC_DebugDCUs>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <DCC_RemoteDebug>false</DCC_RemoteDebug>
+        <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
+        <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
         <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
         <DCC_DebugInformation>0</DCC_DebugInformation>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Cfg_1_OSX64)'!=''">
-        <Debugger_Launcher>/usr/X11/bin/xterm -e &quot;%debuggee%&quot;</Debugger_Launcher>
-        <Manifest_File>(None)</Manifest_File>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Cfg_2)'!=''">
-        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Cfg_2_OSX64)'!=''">
-        <DCC_RemoteDebug>true</DCC_RemoteDebug>
-        <Cfg_2_OSX32>true</Cfg_2_OSX32>
-        <CfgParent>Cfg_2</CfgParent>
-        <Cfg_2>true</Cfg_2>
-        <Debugger_Launcher>/usr/X11/bin/xterm -e &quot;%debuggee%&quot;</Debugger_Launcher>
-        <Manifest_File>(None)</Manifest_File>
+    <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
+        <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
+        <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <BuildConfiguration Include="Debug">
+        <DCCReference Include="main.pas">
+            <Form>Form1</Form>
+            <FormType>dfm</FormType>
+        </DCCReference>
+        <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
-        <BuildConfiguration Include="Release">
+        <BuildConfiguration Include="Debug">
             <Key>Cfg_1</Key>
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
-    <Import Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')" Project="$(BDS)\Bin\CodeGear.Delphi.Targets"/>
     <ProjectExtensions>
         <Borland.Personality>Delphi.Personality.12</Borland.Personality>
-        <Borland.ProjectType/>
+        <Borland.ProjectType>Application</Borland.ProjectType>
         <BorlandProject>
             <Delphi.Personality>
-                <Source>
-                    <Source Name="MainSource">LapeTest.dpr</Source>
-                </Source>
-                <Parameters>
-                    <Parameters Name="UseLauncher">False</Parameters>
-                    <Parameters Name="LoadAllSymbols">True</Parameters>
-                    <Parameters Name="LoadUnspecifiedSymbols">False</Parameters>
-                </Parameters>
-                <VersionInfo>
-                    <VersionInfo Name="IncludeVerInfo">False</VersionInfo>
-                    <VersionInfo Name="AutoIncBuild">False</VersionInfo>
-                    <VersionInfo Name="MajorVer">1</VersionInfo>
-                    <VersionInfo Name="MinorVer">0</VersionInfo>
-                    <VersionInfo Name="Release">0</VersionInfo>
-                    <VersionInfo Name="Build">0</VersionInfo>
-                    <VersionInfo Name="Debug">False</VersionInfo>
-                    <VersionInfo Name="PreRelease">False</VersionInfo>
-                    <VersionInfo Name="Special">False</VersionInfo>
-                    <VersionInfo Name="Private">False</VersionInfo>
-                    <VersionInfo Name="DLL">False</VersionInfo>
-                    <VersionInfo Name="Locale">1043</VersionInfo>
-                    <VersionInfo Name="CodePage">1252</VersionInfo>
-                </VersionInfo>
-                <VersionInfoKeys>
-                    <VersionInfoKeys Name="CompanyName"/>
-                    <VersionInfoKeys Name="FileDescription"/>
-                    <VersionInfoKeys Name="FileVersion">1.0.0.0</VersionInfoKeys>
-                    <VersionInfoKeys Name="InternalName"/>
-                    <VersionInfoKeys Name="LegalCopyright"/>
-                    <VersionInfoKeys Name="LegalTrademarks"/>
-                    <VersionInfoKeys Name="OriginalFilename"/>
-                    <VersionInfoKeys Name="ProductName"/>
-                    <VersionInfoKeys Name="ProductVersion">1.0.0.0</VersionInfoKeys>
-                    <VersionInfoKeys Name="Comments"/>
-                </VersionInfoKeys>
                 <Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dcloffice2k270.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dclofficexp270.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
                 </Excluded_Packages>
+                <Source>
+                    <Source Name="MainSource">LapeTest.dpr</Source>
+                </Source>
             </Delphi.Personality>
-            <Platforms>
-                <Platform value="OSX64">True</Platform>
-                <Platform value="Win32">True</Platform>
-                <Platform value="Win64">True</Platform>
-            </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="OSX32">
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\delphi_PROJECTICNS.icns" Configuration="Debug" Class="ProjectOSXResource">
-                    <Platform Name="OSX64">
-                        <RemoteName>LapeTest.icns</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="LapeTest" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="OSX64">
-                        <RemoteName>LapeTest</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="LapeTest.dSYM" Configuration="Debug" Class="ProjectOSXDebug">
-                    <Platform Name="OSX64">
-                        <RemoteName>LapeTest</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="LapeTest.info.plist" Configuration="Debug" Class="ProjectOSXInfoPList">
-                    <Platform Name="OSX64">
-                        <RemoteName>Info.plist</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="LapeTest.entitlements" Configuration="Debug" Class="ProjectOSXEntitlements">
-                    <Platform Name="OSX64">
+                <DeployFile LocalName="Win32\Debug\LapeTest.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>LapeTest.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
                 <DeployClass Name="AdditionalDebugSymbols">
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win32">
@@ -507,6 +437,7 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win32">
@@ -515,10 +446,12 @@
                 </DeployClass>
                 <DeployClass Name="DependencyFramework">
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                         <Extensions>.framework</Extensions>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                         <Extensions>.framework</Extensions>
                     </Platform>
@@ -527,11 +460,25 @@
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="DependencyModule">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
@@ -554,10 +501,12 @@
                         <Extensions>.dylib</Extensions>
                     </Platform>
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
@@ -583,9 +532,11 @@
                         <Operation>0</Operation>
                     </Platform>
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\Resources\StartUp\</RemoteDir>
                         <Operation>0</Operation>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\Resources\StartUp\</RemoteDir>
                         <Operation>0</Operation>
                     </Platform>
                     <Platform Name="Win32">
@@ -806,9 +757,37 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="ProjectiOSEntitlements"/>
-                <DeployClass Name="ProjectiOSInfoPList"/>
-                <DeployClass Name="ProjectiOSLaunchScreen"/>
+                <DeployClass Name="ProjectiOSEntitlements">
+                    <Platform Name="iOSDevice32">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSInfoPList">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSLaunchScreen">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen</RemoteDir>
+                        <Operation>64</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen</RemoteDir>
+                        <Operation>64</Operation>
+                    </Platform>
+                </DeployClass>
                 <DeployClass Name="ProjectiOSResource">
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
@@ -820,9 +799,32 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="ProjectOSXDebug"/>
-                <DeployClass Name="ProjectOSXEntitlements"/>
-                <DeployClass Name="ProjectOSXInfoPList"/>
+                <DeployClass Name="ProjectOSXDebug">
+                    <Platform Name="OSX64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXEntitlements">
+                    <Platform Name="OSX32">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXInfoPList">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
                 <DeployClass Name="ProjectOSXResource">
                     <Platform Name="OSX32">
                         <RemoteDir>Contents\Resources</RemoteDir>
@@ -855,9 +857,11 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win32">
@@ -903,15 +907,20 @@
                 <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
             </Deployment>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>
     </ProjectExtensions>
-    <Import Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')" Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj"/>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/delphi/main.dfm
+++ b/delphi/main.dfm
@@ -1,0 +1,45 @@
+object Form1: TForm1
+  Left = 0
+  Top = 0
+  Caption = 'Lape'
+  ClientHeight = 410
+  ClientWidth = 457
+  Color = clBtnFace
+  Font.Charset = DEFAULT_CHARSET
+  Font.Color = clWindowText
+  Font.Height = -11
+  Font.Name = 'Tahoma'
+  Font.Style = []
+  OldCreateOrder = False
+  PixelsPerInch = 96
+  TextHeight = 13
+  object ScriptMemo: TMemo
+    Left = 8
+    Top = 8
+    Width = 441
+    Height = 217
+    Lines.Strings = (
+      'begin'
+      '  WriteLn('#39'Hello World'#39');'
+      'end;')
+    TabOrder = 0
+  end
+  object ButtonRun: TButton
+    Left = 8
+    Top = 231
+    Width = 75
+    Height = 25
+    Caption = 'Run'
+    TabOrder = 1
+    OnClick = ButtonRunClick
+  end
+  object OutputMemo: TMemo
+    Left = 8
+    Top = 262
+    Width = 441
+    Height = 139
+    Lines.Strings = (
+      'OutputMemo')
+    TabOrder = 2
+  end
+end

--- a/delphi/main.pas
+++ b/delphi/main.pas
@@ -1,0 +1,88 @@
+unit main;
+
+interface
+
+uses
+  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes,
+  Vcl.Graphics, Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls;
+
+type
+  TForm1 = class(TForm)
+    ScriptMemo: TMemo;
+    ButtonRun: TButton;
+    OutputMemo: TMemo;
+
+    procedure ButtonRunClick(Sender: TObject);
+  end;
+
+var
+  Form1: TForm1;
+
+implementation
+
+{$R *.dfm}
+
+uses
+  lptypes, lpcompiler, lpparser, lpvartypes, lputils, lpinterpreter;
+
+procedure _Write(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  with TForm1(Params^[0]) do
+    OutputMemo.Text := OutputMemo.Text + PlpString(Params^[1])^;
+end;
+
+procedure _WriteLn(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  with TForm1(Params^[0]) do
+    OutputMemo.Text := OutputMemo.Text + LineEnding;
+end;
+
+procedure TForm1.ButtonRunClick(Sender: TObject);
+var
+  T: UInt64;
+  Compiler: TLapeCompiler;
+begin
+  Compiler := nil;
+
+  OutputMemo.Clear();
+
+  try
+    Compiler := TLapeCompiler.Create(TLapeTokenizerString.Create(ScriptMemo.Lines.Text));
+    Compiler.addGlobalMethod('procedure _Write(s: String); override;', @_Write, Self);
+    Compiler.addGlobalMethod('procedure _WriteLn; override;', @_WriteLn, Self);
+
+    InitializePascalScriptBasics(Compiler, [psiTypeAlias]);
+    ExposeGlobals(Compiler);
+
+    try
+      T := GetTickCount64();
+      if Compiler.Compile() then
+        OutputMemo.Lines.Add('Compiling Time: ' + IntToStr(GetTickCount64() - T) + 'ms.')
+      else
+        OutputMemo.Lines.Add('Compiling failed');
+    except
+      on E: Exception do
+      begin
+        OutputMemo.Lines.Add('Compilation error: "' + E.Message + '"');
+        Exit;
+      end;
+    end;
+
+    try
+      T := GetTickCount64();
+      RunCode(Compiler.Emitter.Code, Compiler.Emitter.CodeLen);
+      OutputMemo.Lines.Add('Running Time: ' + IntToStr(GetTickCount64() - T) + 'ms.');
+    except
+      on E: Exception do
+        OutputMemo.Lines.Add(E.Message);
+    end;
+  finally
+    if (Compiler <> nil) then
+      Compiler.Free();
+  end;
+end;
+
+initialization
+  AllocConsole();
+
+end.

--- a/lape.inc
+++ b/lape.inc
@@ -32,7 +32,8 @@
   {$DEFINE Lape_NeedAnsiStringsUnit}
 {$IFEND}
 
+
 // https://bugs.freepascal.org/view.php?id=37305
-{$IF (FPC_FULLVERSION=30200) OR (FPC_FULLVERSION=30201)}
+{$IF (DEFINED(FPC) and ((FPC_FULLVERSION=30200) or (FPC_FULLVERSION=30201)))}
   {$OPTIMIZATION NOLOOPUNROLL}
 {$ENDIF}

--- a/lpeval_wrappers_file.inc
+++ b/lpeval_wrappers_file.inc
@@ -44,7 +44,7 @@ procedure _LapeFindFiles(const Params: PParamArray; const Result: Pointer); {$IF
           end;
       until (FindNext(Info) <> 0);
 
-      FindClose(Info);
+      SysUtils.FindClose(Info);
     end;
   end;
 
@@ -79,7 +79,7 @@ procedure _LapeFindDirectories(const Params: PParamArray; const Result: Pointer)
         end;
       until (FindNext(Info) <> 0);
 
-      FindClose(Info);
+      SysUtils.FindClose(Info);
     end;
   end;
 
@@ -158,7 +158,7 @@ procedure _LapeDeleteDirectory(const Params: PParamArray; const Result: Pointer)
   function DeleteDirectory(Directory: lpString; OnlyChildren: Boolean): Boolean;
   var
     Info: TSearchRec;
-    FileName: lpString;
+    FileName: String;
   begin
     Directory := IncludeTrailingPathDelimiter(ExpandFileName(Directory));
 
@@ -178,11 +178,11 @@ procedure _LapeDeleteDirectory(const Params: PParamArray; const Result: Pointer)
           Continue;
         end;
 
-        if (not DeleteFile(FileName)) then
+        if (not SysUtils.DeleteFile(FileName)) then
           Exit(False);
       until (FindNext(Info) <> 0);
 
-      FindClose(Info);
+      SysUtils.FindClose(Info);
     end;
 
     Result := OnlyChildren or RemoveDir(Directory);
@@ -194,7 +194,7 @@ end;
 
 procedure _LapeDeleteFile(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
-  PBoolean(Result)^ := DeleteFile(PlpString(Params^[0])^);
+  PBoolean(Result)^ := SysUtils.DeleteFile(PlpString(Params^[0])^);
 end;
 
 procedure _LapeRenameFile(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
@@ -309,11 +309,31 @@ begin
 end;
 
 procedure _LapeIncludeLeadingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+
+  {$IFNDEF FPC}
+  function IncludeLeadingPathDelimiter(const Path: lpString): lpString;
+  begin
+    Result := Path;
+    If (Length(Result) = 0) or (Result[1] <> DirectorySeparator) then
+      Result := DirectorySeparator + Result;
+  end;
+  {$ENDIF}
+
 begin
   PlpString(Result)^ := IncludeLeadingPathDelimiter(PlpString(Params^[0])^);
 end;
 
 procedure _LapeExcludeLeadingPathDelimiter(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+
+  {$IFNDEF FPC}
+  function ExcludeLeadingPathDelimiter(const Path: lpString): lpString;
+  begin
+    Result := Path;
+    If (Length(Result) > 0) and (Result[1] = DirectorySeparator) then
+      Delete(Result, 1, 1);
+  end;
+  {$ENDIF}
+
 begin
   PlpString(Result)^ := ExcludeLeadingPathDelimiter(PlpString(Params^[0])^);
 end;

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -146,7 +146,7 @@ type
     Token: EParserToken;
   end;
 
-  TLapeKeywordDictionary = specialize TLapeUniqueStringDictionary<EParserToken>;
+  TLapeKeywordDictionary = {$IFDEF FPC}specialize{$ENDIF} TLapeUniqueStringDictionary<EParserToken>;
 
   TLapeTokenizerBase = class(TLapeBaseDeclClass)
   protected
@@ -214,7 +214,6 @@ type
     property Pos: Integer read FPos write setPos;
     property Len: Integer read FLen;
     property InPeek: Boolean read FInPeek;
-  published
     property OnParseDirective: TLapeParseDirective read FOnParseDirective write FOnParseDirective;
     property OnHandleDirective: TLapeHandleDirective read FOnHandleDirective write FOnHandleDirective;
   end;
@@ -229,7 +228,6 @@ type
     procedure Reset(ClearDoc: Boolean = False); override;
     constructor Create(ADoc: lpString; AFileName: lpString = ''); reintroduce; virtual;
     function getChar(Offset: Integer = 0): lpChar; override;
-  published
     property Doc: lpString read FDoc write setDoc;
   end;
 
@@ -674,7 +672,7 @@ var
   tmpDocPos: TDocPos;
   CommentLevel: Integer;
 
-  procedure NextPos_CountLines; inline;
+  procedure NextPos_CountLines; {$IFDEF FPC}inline;{$ENDIF}
   begin
     repeat
       case CurChar of
@@ -690,7 +688,7 @@ var
     until (not (CurChar in [#9, #32, #10, #13]));
   end;
 
-  function Alpha: EParserToken; inline;
+  function Alpha: EParserToken; {$IFDEF FPC}inline;{$ENDIF}
   var
     Token: EParserToken;
   begin
@@ -1372,7 +1370,7 @@ var
 begin
   StrList := TStringList.Create();
   try
-    StrList.LoadFromFile(string(AFileName));
+    StrList.LoadFromFile(string(AFileName), TEncoding.ANSI);
     inherited Create(lpString(StrList.Text), lpString(AFileName));
   finally
     StrList.Free();

--- a/lpsort.inc
+++ b/lpsort.inc
@@ -1,0 +1,55 @@
+{%MainUnit lptypes.pas}
+
+begin
+  Item := GetMemory(ElSize);
+
+  repeat
+    Lo := iLo;
+    Hi := iHi;
+    Mid := Weights[(Lo + Hi) shr 1];
+    repeat
+      if SortUp then
+      begin
+        while (Weights[Lo] < Mid) do Inc(Lo);
+        while (Weights[Hi] > Mid) do Dec(Hi);
+      end else
+      begin
+        while (Weights[Lo] > Mid) do Inc(Lo);
+        while (Weights[Hi] < Mid) do Dec(Hi);
+      end;
+      if (Lo <= Hi) then
+      begin
+        if (Lo <> Hi) then
+        begin
+          T := Weights[Lo];
+          Weights[Lo] := Weights[Hi];
+          Weights[Hi] := T;
+
+          Move(Arr[Lo * ElSize], Item^, ElSize);
+          Move(Arr[Hi * ElSize], Arr[Lo * ElSize], ElSize);
+          Move(Item^, Arr[Hi * ElSize], ElSize);
+        end;
+        Inc(Lo);
+        Dec(Hi);
+      end;
+    until Lo > Hi;
+
+    // sort the smaller range recursively
+    // sort the bigger range via the loop
+    // Reasons: memory usage is O(log(n)) instead of O(n) and loop is faster than recursion
+    if Hi - iLo < iHi - Lo then
+    begin
+      if iLo < Hi then
+        QuickSort(Arr, ElSize, Weights, iLo, Hi, SortUp);
+      iLo := Lo;
+    end else
+    begin
+      if Lo < iHi then
+        QuickSort(Arr, ElSize, Weights, Lo, iHi, SortUp);
+      iHi := Hi;
+    end;
+  until iLo >= iHi;
+
+  FreeMem(Item);
+end;
+

--- a/lptree.pas
+++ b/lptree.pas
@@ -6341,13 +6341,19 @@ end;
 procedure TLapeTree_CaseBranch.setFallThroughOffset(Offset: Integer);
 var
   i: Integer;
+  FlowStatement: TLapeFlowStatement;
 begin
   for i := 0 to FFallThroughStatements.Count - 1 do
-    with FFallThroughStatements[i] do
+  begin
+    FlowStatement := FFallThroughStatements[i];
+    with FlowStatement do
       if JumpSafe then
         FCompiler.Emitter._JmpSafeR(Offset - CodeOffset, CodeOffset, @DocPos)
       else
         FCompiler.Emitter._JmpR(Offset - CodeOffset, CodeOffset, @DocPos);
+
+    FFallThroughStatements[i] := FlowStatement;
+  end;
 end;
 
 procedure TLapeTree_CaseBranch.setCondition(Node: TLapeTree_ExprBase);

--- a/lptypes.pas
+++ b/lptypes.pas
@@ -1,4 +1,4 @@
-{
+﻿{
   Author: Niels A.D
   Project: Lape (https://github.com/nielsAD/lape)
   License: GNU Lesser GPL (http://www.gnu.org/licenses/lgpl.html)
@@ -19,14 +19,6 @@ const
   LapeSystemCaseSensitive = {$IFDEF Unix}True{$ELSE}False{$ENDIF};
 
 type
-  UInt8 = Byte;
-  Int8 = ShortInt;
-  UInt16 = Word;
-  Int16 = SmallInt;
-  UInt32 = LongWord;
-  Int32 = LongInt;
-  //UInt64 = QWord;    Already defined
-  //Int64 = Int64;     Already defined
 
   PUInt8 = ^UInt8;
   PInt8 = ^Int8;
@@ -35,7 +27,7 @@ type
   PUInt32 = ^UInt32;
   PInt32 = ^Int32;
   PUInt64 = ^UInt64;
-  //PInt64 = ^Int64;   Already defined
+  PInt64 = ^Int64;
 
   PByteBool = ^ByteBool;
 
@@ -645,20 +637,12 @@ type
     property ManagedDeclarations: TLapeDeclarationList read FManagedDecls write setManagedDecls;
   end;
 
-  {$IFDEF FPC}generic{$ENDIF} TLapeSorter<_T> = class
-  public
-  type
-    TWeightArray = {$IFDEF FPC}specialize{$ENDIF} TArray<_T>;
-  public
-    class procedure QuickSort(const Arr: PByte; const ElSize: SizeInt; var Weights: TWeightArray; iLo, iHi: SizeInt; const SortUp: Boolean); static;
-  end;
-
 const
   op_Invoke = op_Index;
   op_Label = op_Addr;
 
   {$IFNDEF FPC}
-  LineEnding = #13#10;
+  LineEnding = {$IFDEF MSWINDOWS}#13#10{$ELSE}#10{$ENDIF};
   DirectorySeparator = PathDelim;
   {$ENDIF}
 
@@ -709,6 +693,7 @@ const
     {$MESSAGE Fatal 'TCodePos should be <= Pointer for universal methods'}
   {$IFEND}
 
+  LapeBaseTypes = [Low(ELapeBaseType)..High(ELapeBaseType)];
   LapeIntegerTypes = [Low(LapeIntegerTypeRange)..High(LapeIntegerTypeRange)];
   LapeSignedIntegerTypes = [ltInt8, ltInt16, ltInt32, ltInt64];
   LapeUnsignedIntegerTypes = [ltUInt8, ltUInt16, ltUInt32, ltUInt64];
@@ -808,9 +793,9 @@ procedure _Insert16(Arr: PUInt16; var Index: Integer);
 procedure _Insert32(Arr: PUInt32; var Index: Integer);
 procedure _Insert64(Arr: PUInt64; var Index: Integer);
 
-procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TIntegerArray; const SortUp: Boolean);
-procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TInt64Array;  const SortUp: Boolean);
-procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TExtendedArray; const SortUp: Boolean);
+procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TIntegerArray; const SortUp: Boolean); overload;
+procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TInt64Array;  const SortUp: Boolean); overload;
+procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TExtendedArray; const SortUp: Boolean); overload;
 
 {$IFDEF Lape_TrackObjects}
 var
@@ -1217,33 +1202,48 @@ begin
 end;
 
 procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TIntegerArray; const SortUp: Boolean);
-type
-  TSorter = specialize TLapeSorter<Integer>;
-begin
-  if (Len <> Length(Weights)) then
-    LapeExceptionFmt(lpeArrayLengthsDontMatch, [Format('%d, %d', [Len, Length(Weights)])]);
 
-  TSorter.QuickSort(Arr, ElSize, Weights, Low(Weights), High(Weights), SortUp);
+  procedure QuickSort(const Arr: PByte; const ElSize: SizeInt; var Weights: TIntegerArray; iLo, iHi: SizeInt; const SortUp: Boolean);
+  var
+    Lo, Hi: SizeInt;
+    Mid, T: Integer;
+    Item: PByte;
+  begin
+    {$i lpsort.inc}
+  end;
+
+begin
+  QuickSort(Arr, ElSize, Weights, Low(Weights), High(Weights), SortUp);
 end;
 
 procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TInt64Array; const SortUp: Boolean);
-type
-  TSorter = specialize TLapeSorter<Int64>;
-begin
-  if (Len <> Length(Weights)) then
-    LapeExceptionFmt(lpeArrayLengthsDontMatch, [Format('%d, %d', [Len, Length(Weights)])]);
 
-  TSorter.QuickSort(Arr, ElSize, Weights, Low(Weights), High(Weights), SortUp);
+  procedure QuickSort(const Arr: PByte; const ElSize: SizeInt; var Weights: TInt64Array; iLo, iHi: SizeInt; const SortUp: Boolean);
+  var
+    Lo, Hi: SizeInt;
+    Mid, T: Int64;
+    Item: PByte;
+  begin
+    {$i lpsort.inc}
+  end;
+
+begin
+  QuickSort(Arr, ElSize, Weights, Low(Weights), High(Weights), SortUp);
 end;
 
 procedure _Sort(const Arr: PByte; const ElSize, Len: SizeInt; var Weights: TExtendedArray; const SortUp: Boolean);
-type
-  TSorter = specialize TLapeSorter<Extended>;
-begin
-  if (Len <> Length(Weights)) then
-    LapeExceptionFmt(lpeArrayLengthsDontMatch, [Format('%d, %d', [Len, Length(Weights)])]);
 
-  TSorter.QuickSort(Arr, ElSize, Weights, Low(Weights), High(Weights), SortUp);
+  procedure QuickSort(const Arr: PByte; const ElSize: SizeInt; var Weights: TExtendedArray; iLo, iHi: SizeInt; const SortUp: Boolean);
+  var
+    Lo, Hi: SizeInt;
+    Mid, T: Extended;
+    Item: PByte;
+  begin
+    {$i lpsort.inc}
+  end;
+
+begin
+  QuickSort(Arr, ElSize, Weights, Low(Weights), High(Weights), SortUp);
 end;
 
 function TLapeBaseClass._AddRef: Integer; {$IFDEF Interface_CDecl}cdecl{$ELSE}stdcall{$ENDIF};
@@ -2163,7 +2163,7 @@ begin
   if (Decl.FName <> '') then
     Inc(FNamedCount);
 
-  Decl.FNameChangeNotifier.AddProc(@NameChanged);
+  Decl.FNameChangeNotifier.AddProc({$IFDEF FPC}@{$ENDIF}NameChanged);
 end;
 
 procedure TLapeDeclCollection_Dictionary._Grow;
@@ -2452,7 +2452,7 @@ end;
 
 function TLapeDeclCollection_List.ExportToArray: TLapeDeclArray;
 begin
-  Result := FList.ExportToArray();
+  Result := TLapeDeclArray(FList.ExportToArray());
 end;
 
 constructor TLapeDeclarationList.Create(AList: TLapeDeclCollection; ManageDeclarations: Boolean);
@@ -2755,64 +2755,6 @@ end;
 procedure TLapeManagingDeclaration.ClearSubDeclarations;
 begin
   FManagedDecls.Clear();
-end;
-
-class procedure TLapeSorter.QuickSort{$IFNDEF FPC}<_T>{$ENDIF}(const Arr: PByte; const ElSize: SizeInt; var Weights: TWeightArray; iLo, iHi: SizeInt; const SortUp: Boolean);
-var
-  Lo, Hi: SizeInt;
-  Mid, T: _T;
-  Item: PByte;
-begin
-  Item := GetMem(ElSize);
-
-  repeat
-    Lo := iLo;
-    Hi := iHi;
-    Mid := Weights[(Lo + Hi) shr 1];
-    repeat
-      if SortUp then
-      begin
-        while (Weights[Lo] < Mid) do Inc(Lo);
-        while (Weights[Hi] > Mid) do Dec(Hi);
-      end else
-      begin
-        while (Weights[Lo] > Mid) do Inc(Lo);
-        while (Weights[Hi] < Mid) do Dec(Hi);
-      end;
-      if (Lo <= Hi) then
-      begin
-        if (Lo <> Hi) then
-        begin
-          T := Weights[Lo];
-          Weights[Lo] := Weights[Hi];
-          Weights[Hi] := T;
-
-          Move(Arr[Lo * ElSize], Item^, ElSize);
-          Move(Arr[Hi * ElSize], Arr[Lo * ElSize], ElSize);
-          Move(Item^, Arr[Hi * ElSize], ElSize);
-        end;
-        Inc(Lo);
-        Dec(Hi);
-      end;
-    until Lo > Hi;
-
-    // sort the smaller range recursively
-    // sort the bigger range via the loop
-    // Reasons: memory usage is O(log(n)) instead of O(n) and loop is faster than recursion
-    if Hi - iLo < iHi - Lo then
-    begin
-      if iLo < Hi then
-        QuickSort(Arr, ElSize, Weights, iLo, Hi, SortUp);
-      iLo := Lo;
-    end else
-    begin
-      if Lo < iHi then
-        QuickSort(Arr, ElSize, Weights, Lo, iHi, SortUp);
-      iHi := Hi;
-    end;
-  until iLo >= iHi;
-
-  FreeMem(Item);
 end;
 
 {$IFDEF Lape_TrackObjects}

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -368,7 +368,7 @@ type
     Res: TLapeType;
     IsOperator: Boolean;
     HintDirectives: ELapeHintDirectives;
-    DeprecatedHint: String;
+    DeprecatedHint: lpString;
 
     constructor Create(ACompiler: TLapeCompilerBase; AParams: TLapeParameterList; ARes: TLapeType = nil; AName: lpString = ''; ADocPos: PDocPos = nil); reintroduce; overload; virtual;
     constructor Create(ACompiler: TLapeCompilerBase; AParams: array of TLapeType; AParTypes: array of ELapeParameterType; AParDefaults: array of TLapeGlobalVar; ARes: TLapeType = nil; AName: lpString = ''; ADocPos: PDocPos = nil); reintroduce; overload; virtual;
@@ -609,7 +609,7 @@ type
   end;
 
   TLapeHint = procedure(Sender: TLapeCompilerBase; Msg: lpString) of object;
-  TLapeBaseTypesDictionary = specialize TLapeUniqueStringDictionary<TLapeType>;
+  TLapeBaseTypesDictionary = {$IFDEF FPC}specialize{$ENDIF}TLapeUniqueStringDictionary<TLapeType>;
 
   TLapeCompilerBase = class(TLapeBaseDeclClass)
   protected
@@ -696,7 +696,6 @@ type
     property GlobalDeclarations: TLapeDeclarationList read FGlobalDeclarations;
     property ManagedDeclarations: TLapeDeclarationList read FManagedDeclarations;
     property Globals[AName: lpString]: TLapeGlobalVar read getGlobalVar; default;
-  published
     property Emitter: TLapeCodeEmitter read FEmitter write setEmitter;
     property Options: ECompilerOptionsSet read FOptions write setOptions default Lape_OptionsDef;
     property Options_PackRecords: UInt8 read FBaseOptions_PackRecords write setPackRecords default Lape_PackRecordsDef;
@@ -771,7 +770,7 @@ procedure ClearBaseTypes(var Arr: TLapeBaseTypes; DoFree: Boolean);
 var
   BaseType: ELapeBaseType;
 begin
-  for BaseType := Low(ELapeBaseType) to High(ELapeBaseType) do
+  for BaseType in LapeBaseTypes do
     if (Arr[BaseType] <> nil) then
       if DoFree then
         FreeAndNil(Arr[BaseType])
@@ -3988,7 +3987,7 @@ begin
   LoadBaseTypes(FBaseTypes, Self);
 
   FBaseTypesDictionary := TLapeBaseTypesDictionary.Create(nil, 256);
-  for BaseType in ELapeBaseType do
+  for BaseType in LapeBaseTypes do
     if (FBaseTypes[BaseType] <> nil) then
       FBaseTypesDictionary[FBaseTypes[BaseType].Name] := FBaseTypes[BaseType];
 
@@ -3996,7 +3995,7 @@ begin
 
   FGlobalDeclarations := TLapeDeclarationList.Create(nil);
   FManagedDeclarations := TLapeDeclarationList.Create(nil);
-  for BaseType in ELapeBaseType do
+  for BaseType in LapeBaseTypes do
     FCachedDeclarations[BaseType] := TLapeVarMap.Create(nil, dupIgnore, True, '', True);
 end;
 
@@ -4010,7 +4009,7 @@ begin
   FreeAndNil(FBaseTypesDictionary);
   FreeAndNil(FGlobalDeclarations);
   FreeAndNil(FManagedDeclarations);
-  for BaseType in ELapeBaseType do
+  for BaseType in LapeBaseTypes do
     FreeAndNil(FCachedDeclarations[BaseType]);
 
   ClearBaseTypes(FBaseTypes, True);
@@ -4027,7 +4026,7 @@ begin
   FManagedDeclarations.Delete(TLapeVar, True);
   FGlobalDeclarations.Clear();
   FManagedDeclarations.Clear();
-  for BaseType in ELapeBaseType do
+  for BaseType in LapeBaseTypes do
     FCachedDeclarations[BaseType].Clear();
   Reset();
 end;

--- a/tests/Arithmetics_Integer.lap
+++ b/tests/Arithmetics_Integer.lap
@@ -378,8 +378,8 @@ begin
   Assert(b - a = -(a - b), 'b - a <> -(a - b)');
   Assert(b - a =  -a + b,  'b - a <>  -a + b');
 
-  Assert(a - b = -6, 'a - b');
-  Assert(b - a =  6, 'b - a');
+  Assert(Int64(a - b) = -6, 'a - b');
+  Assert(UInt64(b - a) =  6, 'b - a');
 
   Assert(a * b = b * a, 'a * b <> b * a');
   Assert(a + a = 2 * a, 'a + a <> 2 * a');

--- a/tests/RunTests/LapeTest.dpr
+++ b/tests/RunTests/LapeTest.dpr
@@ -3,8 +3,8 @@ program LapeTest;
 {$APPTYPE CONSOLE}
 
 uses
-  SysUtils,
-  lptest;
+  Classes, SysUtils,
+  lptest, lptypes;
 
 begin
   try

--- a/tests/RunTests/lptest.pas
+++ b/tests/RunTests/lptest.pas
@@ -135,7 +135,7 @@ var
     if (FindFirst(Folder + '*.lap', faAnyFile - faDirectory, Res) = 0) then
     try
       repeat
-        Write(Format('Testing %30s :: ', [ExtractFileName(Res.Name)]));
+        Write(Format('Testing %35s :: ', [ExtractFileName(Res.Name)]));
         Inc(Result);
 
         Output := '';


### PR DESCRIPTION
All normal tests pass on Delphi 10.4 Win32 & Win64 and silly PA Server thing on MacOS 64.

A few bugs showed themselfs and have been solved:
- ParseExpression integer/float constants now are cached with correct signage.
- SetLength: Check if `Left <> nil` SetLength(nil) is bad... The real fix for #147.
- StaticArrays use `TLapeTree_For` not niels raw style looping.


