### PR TITLE
Remove constref methods - constant self is now a variable copy

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -2020,7 +2020,7 @@ begin
     ResetStack := False;
 
   try
-    isNext([tk_kw_UnImplemented, tk_kw_Experimental, tk_kw_Deprecated, tk_kw_ConstRef, tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override, tk_kw_Static]);
+    isNext([tk_kw_UnImplemented, tk_kw_Experimental, tk_kw_Deprecated, tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override, tk_kw_Static]);
     OldDeclaration := getDeclarationNoWith(FuncName, FStackInfo.Owner);
     LocalDecl := (OldDeclaration <> nil) and hasDeclaration(OldDeclaration, FStackInfo.Owner, True, False);
 

--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -2027,19 +2027,7 @@ begin
     if (OldDeclaration <> nil) and (FuncHeader is TLapeType_MethodOfType) and (not LocalDecl) and (not TLapeType_MethodOfType(FuncHeader).ObjectType.HasSubDeclaration(OldDeclaration, bTrue)) then
       OldDeclaration := nil;
 
-    if (Tokenizer.Tok = tk_kw_ConstRef) then
-    begin
-      ParseExpressionEnd(tk_sym_SemiColon, True, False);
-      if (not (FuncHeader is TLapeType_MethodOfType)) then
-        LapeException(lpeMethodOfObjectExpected, Tokenizer.DocPos);
-
-      RemoveSelfVar();
-      TLapeType_MethodOfType(FuncHeader).SelfParam := lptConstRef;
-      AddSelfVar(lptConstRef, TLapeType_MethodOfType(FuncHeader).ObjectType);
-
-      isNext([tk_kw_UnImplemented, tk_kw_Experimental, tk_kw_Deprecated, tk_kw_External, tk_kw_Forward, tk_kw_Overload, tk_kw_Override]);
-    end
-    else if (Tokenizer.Tok = tk_kw_Static) then
+    if (Tokenizer.Tok = tk_kw_Static) then
     begin
       ParseExpressionEnd(tk_sym_SemiColon, True, False);
       if MethodOfObject(FuncHeader) then

--- a/lptree.pas
+++ b/lptree.pas
@@ -3442,6 +3442,10 @@ var
   TempNullVar, TempPtrVar, TempSelfVar: TResVar;
 begin
   Result := NullResVar;
+
+  TempPtrVar := NullResVar;
+  TempSelfVar := NullResVar;
+
   IdentExpr := RealIdent;
   Assert(IdentExpr <> nil);
 
@@ -3547,6 +3551,11 @@ begin
     IdentVar.Spill(1);
     for i := 0 to High(ParamVars) do
       ParamVars[i].Spill(1);
+
+    if (TempPtrVar.VarPos.MemPos <> NullResVar.VarPos.MemPos) then
+      TempPtrVar.Spill(1);
+    if (TempSelfVar.VarPos.MemPos <> NullResVar.VarPos.MemPos) then
+      TempSelfVar.Spill(1);
   end;
 end;
 

--- a/tests/MethodOfType_Constant.lap
+++ b/tests/MethodOfType_Constant.lap
@@ -1,0 +1,34 @@
+{$assertions on}
+
+type
+  TPoint = record
+    X, Y: Integer;
+  end;
+
+procedure TPoint.Swap;
+begin
+  Assert(Self = [1, 2]);
+
+  System.Swap(Self.X, Self.Y);
+end;
+
+function GetPoint: TPoint;
+begin
+  Result := [1, 2];
+end;
+
+const
+  A: TPoint = [1, 2];
+
+var
+  B: TPoint = [1, 2];
+
+begin
+  A.Swap();
+  Assert(A = [1, 2]);
+
+  B.Swap();
+  Assert(B = [2, 1]);
+
+  GetPoint().Swap();
+end;

--- a/tests/Method_OfType.lap
+++ b/tests/Method_OfType.lap
@@ -10,12 +10,12 @@ begin
   Result := StrToIntDef(s, Def);
 end;
 
-function NativeInt.Next(i: NativeInt): NativeInt; constref;
+function NativeInt.Next(i: NativeInt): NativeInt;
 begin
   Result := Self + i;
 end;
 
-function NativeInt.Next(s: string): NativeInt; constref; overload;
+function NativeInt.Next(s: string): NativeInt; overload;
 begin
   Result := Next(Self.Create(s));
 end;


### PR DESCRIPTION
FPC style - make a copy of Self if it's a constant. This is done the same way "normal" method parameters are handled so beware  with types that are passed by references such as dyn arrays.

Behavior is a bit less obvious, but still makes sense and most importantly removes all the constref crazyness.
No tests failed so at a high level nothing breaks. (aside from removing constref from headers)

@nielsAD 