### PR TITLE
Explicitly scoped enums

### DIFF
--- a/lpeval.pas
+++ b/lpeval.pas
@@ -142,7 +142,7 @@ var
 
   _LapeToString_Set: lpString =
     'function _%sSetToString(ASet: ConstPointer;'                                        + LineEnding +
-    '  AToString: private function(constref Enum): string;'                              + LineEnding +
+    '  AToString: private function(constref AEnum): string;'                              + LineEnding +
     '  Lo, Hi: SizeInt): string;'                                                        + LineEnding +
     'type'                                                                               + LineEnding +
     '  TEnum = (se0, se1 = %d);'                                                         + LineEnding +

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -38,6 +38,7 @@ type
     tk_kw_DownTo,
     tk_kw_Else,
     tk_kw_End,
+    tk_kw_Enum,
     tk_kw_Except,
     tk_kw_Experimental,
     tk_kw_External,
@@ -250,7 +251,7 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..52 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..53 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';           Token: tk_op_AND),
       (Keyword: 'DIV';           Token: tk_op_DIV),
       (Keyword: 'IN';            Token: tk_op_IN),
@@ -273,6 +274,7 @@ const
       (Keyword: 'DOWNTO';        Token: tk_kw_DownTo),
       (Keyword: 'ELSE';          Token: tk_kw_Else),
       (Keyword: 'END';           Token: tk_kw_End),
+      (Keyword: 'ENUM';          Token: tk_kw_Enum),
       (Keyword: 'EXCEPT';        Token: tk_kw_Except),
       (Keyword: 'EXPERIMENTAL';  Token: tk_kw_Experimental),
       (Keyword: 'EXTERNAL';      Token: tk_kw_External),

--- a/tests/Enum.lap
+++ b/tests/Enum.lap
@@ -1,0 +1,14 @@
+{$assertions on}
+
+type
+  EEnum = (testA, testB);
+  EScopedEnum = enum(testA, testB);
+
+var
+  e: EEnum = testB;
+  scoped: EScopedEnum = EScopedEnum.testB;
+
+begin
+  Assert(ToString(e) = 'testB');
+  Assert(ToString(scoped) = 'EScopedEnum.testB');
+end;


### PR DESCRIPTION
Added `enum` keyword so that
```pascal
EScopedEnum = enum(testA, testB);
```

Is equal to:

```pascal
{$scopedenums on}
EScopedEnum = (testA, testB);
{$scopedenums off}
```

