### PR TITLE
Dont allow invoking non-static methods on a type

### DIFF
--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -109,6 +109,7 @@ const
   lpeParentOutOfScope = 'Parent declaration is out of scope';
   lpeRuntime = 'Runtime error: "%s"';
   lpeStatementNotAllowed = 'Statement not allowed here';
+  lpeStaticMethodExpected = 'Variable expected. "%s" is not a static method';
   lpeTooMuchParameters = 'Too many parameters found';
   lpeTypeExpected = 'Type expected';
   lpeUnClosedComment = 'Unclosed comment';

--- a/lptree.pas
+++ b/lptree.pas
@@ -3486,6 +3486,9 @@ begin
 
       if (IdentVar.VarType is TLapeType_MethodOfObject) and (IdentVar.VarPos.MemPos <> mpStack) then
       begin
+        if (IdentVar.VarType is TLapeType_MethodOfType) and (FExpr is TLapeTree_GlobalVar) then
+          LapeExceptionFmt(lpeStaticMethodExpected, [GetMethodName(TLapeTree_GlobalVar(FExpr).GlobalVar.VarType)], Expr.DocPos);
+
         if (IdentVar.VarType is TLapeType_MethodOfType) and
            (not (TLapeType_MethodOfType(IdentVar.VarType).SelfParam in Lape_ValParams)) and
            (not IdentVar.Readable) then

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -710,6 +710,7 @@ function getTypeArray(Arr: array of TLapeType): TLapeTypeArray;
 procedure ClearBaseTypes(var Arr: TLapeBaseTypes; DoFree: Boolean);
 procedure LoadBaseTypes(var Arr: TLapeBaseTypes; Compiler: TLapeCompilerBase);
 
+function GetMethodName(VarType: TLapeType): lpString;
 function MethodOfObject(VarType: TLapeType): Boolean;
 function ValidFieldName(Field: TLapeGlobalVar): Boolean; overload;
 function ValidFieldName(Field: TResVar): Boolean; overload;
@@ -807,6 +808,22 @@ begin
   Arr[ltUnicodeString] := TLapeType_UnicodeString.Create(Compiler, LapeTypeToString(ltUnicodeString));
   Arr[ltVariant] := TLapeType_Variant.Create(Compiler, LapeTypeToString(ltVariant));
   Arr[ltPointer] := TLapeType_Pointer.Create(Compiler, nil, False, LapeTypeToString(ltPointer));
+end;
+
+function GetMethodName(VarType: TLapeType): lpString;
+begin
+  Result := '';
+
+  if (VarType is TLapeType_OverloadedMethod) and (VarType.ManagedDeclarations.Count > 0) then
+    VarType := TLapeGlobalVar(VarType.ManagedDeclarations[0]).VarType;
+
+  if (VarType is TLapeType_Method) then
+  begin
+    if (VarType is TLapeType_MethodOfType) then
+      Result := TLapeType_MethodOfType(VarType).ObjectType.Name + '.' + VarType.Name
+    else
+      Result := VarType.Name;
+  end;
 end;
 
 function MethodOfObject(VarType: TLapeType): Boolean;

--- a/tests/MethodOfType_Static.lap
+++ b/tests/MethodOfType_Static.lap
@@ -1,0 +1,18 @@
+procedure Int32.Test;
+begin
+end;
+
+procedure Int32.TestStatic; static;
+begin
+end;
+
+var
+  i: Integer;
+
+begin
+  i.Test();
+  i.TestStatic();
+
+  Int32.TestStatic();
+  Int32.Test(); // Compilation error: "Variable expected. "Int32.Test" is not a static method at line 17, column 8"
+end;

--- a/tests/MethodOfType_Static.txt
+++ b/tests/MethodOfType_Static.txt
@@ -1,0 +1,1 @@
+Variable expected. "Int32.Test" is not a static method at line 17, column 8 in file "MethodOfType_Static.lap"


### PR DESCRIPTION
```pascal
procedure Int32.Test;
begin
end;

begin
  Int32.Test();
end.
```
Now will error with:
`Compilation error: "Variable expected. "Int32.Test" is not a static method"`