### PR TITLE
Remove TreeMethodMap & Fix misplaced `setReadWrite` in ParseMethod

### DIFF
--- a/tests/Bugs/InheritedAddrFold.lap
+++ b/tests/Bugs/InheritedAddrFold.lap
@@ -1,0 +1,14 @@
+{$assertions on}
+
+procedure Foo; 
+begin
+end;
+
+procedure Foo; override;
+begin
+  Assert(PtrUInt(@inherited) <> PtrUInt(-1));
+end;
+
+begin
+  Foo();
+end;

--- a/tests/Bugs/OverrideImportedScriptMeth.lap
+++ b/tests/Bugs/OverrideImportedScriptMeth.lap
@@ -1,0 +1,17 @@
+{$assertions on}
+
+procedure _Swap(var A,B; Size: SizeInt); override;
+begin
+  Assert(PtrUInt(@inherited) <> PtrUInt(-1));
+
+  inherited();
+end;
+
+var i: Integer = 1;
+var j: Integer = 2;
+begin
+  _Swap(i, j, SizeOf(Integer));
+
+  Assert(i=2);
+  Assert(j=1);
+end;


### PR DESCRIPTION
1) Removed the compilers `TreeMethodMap` which is used for script method overriding. For such a small amount of usage it's not needed, rather the delayed tree is just looped.
This also fixes a bug where overriding a script method that was "imported" such as with `addDelayedCode` and `inherited` was a invalid value because `TreeMethodMap` was cleared before script compile.

2) `Method.setReadWrite(False, False)` in `ParseMethod` was misplaced where it might not be applied on a newly created method.