### PR TITLE
Add GetCallerLocation, GetExceptionLocation and the ability to raise an exception at one of these locations

### DIFF
--- a/lpcodeemitter.pas
+++ b/lpcodeemitter.pas
@@ -113,6 +113,10 @@ type
     function _IsInternal(Pos: PDocPos = nil): Integer; overload;
     function _GetExceptionMessage(var Offset: Integer; Pos: PDocPos = nil): Integer; overload;
     function _GetExceptionMessage(Pos: PDocPos = nil): Integer; overload;
+    function _GetExceptionLocation(var Offset: Integer; Pos: PDocPos = nil): Integer; overload;
+    function _GetExceptionLocation(Pos: PDocPos = nil): Integer; overload;
+    function _GetCallerLocation(var Offset: Integer; Pos: PDocPos = nil): Integer; overload;
+    function _GetCallerLocation(Pos: PDocPos = nil): Integer; overload;
     function _ReRaiseException(var Offset: Integer; Pos: PDocPos = nil): Integer; overload;
     function _ReRaiseException(Pos: PDocPos = nil): Integer; overload;
     function _InitStackLen(Len: TStackOffset; var Offset: Integer; Pos: PDocPos = nil): Integer; overload;
@@ -503,6 +507,18 @@ begin
   IncStack(SizeOf(ShortString));
 end;
 
+function TLapeCodeEmitterBase._GetExceptionLocation(var Offset: Integer; Pos: PDocPos = nil): Integer;
+begin
+  Result := _op(ocGetExceptionLocation, Offset, Pos);
+  IncStack(SizeOf(Pointer));
+end;
+
+function TLapeCodeEmitterBase._GetCallerLocation(var Offset: Integer; Pos: PDocPos = nil): Integer;
+begin
+  Result := _op(ocGetCallerLocation, Offset, Pos);
+  IncStack(SizeOf(Pointer));
+end;
+
 function TLapeCodeEmitterBase._ReRaiseException(var Offset: Integer; Pos: PDocPos = nil): Integer;
 begin
   Result := _op(ocReRaiseException, Offset, Pos);
@@ -657,6 +673,10 @@ function TLapeCodeEmitterBase._IsInternal(Pos: PDocPos = nil): Integer;
   var o: Integer; begin o := -1; Result := _IsInternal(o, Pos); end;
 function TLapeCodeEmitterBase._GetExceptionMessage(Pos: PDocPos = nil): Integer;
   var o: Integer; begin o := -1; Result := _GetExceptionMessage(o, Pos); end;
+function TLapeCodeEmitterBase._GetExceptionLocation(Pos: PDocPos = nil): Integer;
+  var o: Integer; begin o := -1; Result := _GetExceptionLocation(o, Pos); end;
+function TLapeCodeEmitterBase._GetCallerLocation(Pos: PDocPos = nil): Integer;
+  var o: Integer; begin o := -1; Result := _GetCallerLocation(o, Pos); end;
 function TLapeCodeEmitterBase._ReRaiseException(Pos: PDocPos): Integer;
   var o: Integer; begin o := -1; Result := _ReRaiseException(o, Pos); end;
 

--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -980,6 +980,8 @@ begin
     '!BaseDefinitionsDelayedCode'
   );
 
+  addGlobalFunc('function _LocationToStr(DocPos: Pointer): string;', @_LapeLocationToStr);
+
   addGlobalFunc('procedure _Write(s: string);', @_LapeWrite);
   addGlobalFunc('procedure _WriteLn();', @_LapeWriteLn);
 
@@ -1022,8 +1024,9 @@ begin
   addGlobalFunc('function CompareMem(constref p1, p2; Length: SizeInt): EvalBool;', @_LapeCompareMem);
 
   addGlobalFunc('function Assigned(constref p): EvalBool;', @_LapeAssigned);
-  //addGlobalFunc('procedure RaiseException(Ex: TExceptionObject); overload;', @_LapeRaise);
-  addGlobalFunc('procedure RaiseException(Ex: string); overload;', @_LapeRaiseString);
+
+  addGlobalFunc('procedure RaiseException(Message: string); overload;', @_LapeRaiseString);
+  addGlobalFunc('procedure RaiseException(Message: String; DocPos: Pointer); overload;', @_LapeRaiseStringWithDocPos);
 
   addGlobalFunc('procedure UniqueString(var Str: AnsiString); overload;', @_LapeAStr_Unique);
   addGlobalFunc('procedure UniqueString(var Str: WideString); overload;', @_LapeWStr_Unique);
@@ -3255,7 +3258,11 @@ begin
               else
               begin
                 if (Method is TLapeTree_InternalMethod) and (TLapeTree_InternalMethod(Method).ForceParam and (not (Tokenizer.Tok in ReturnOn))) then
-                  Method.addParam(EnsureExpression(ParseExpression(ReturnOn, False)));
+                begin
+                  Method.addParam(EnsureExpression(ParseExpression(ReturnOn, Tokenizer.Tok = tk_kw_At)));
+                  if (Method is TLapeTree_InternalMethod_Raise) and (Tokenizer.Tok = tk_kw_At) then
+                    Method.addParam(EnsureExpression(ParseExpression(ReturnOn, True)));
+                end;
 
                 VarStack.Push(Method);
                 Method := nil;
@@ -3778,6 +3785,10 @@ begin
   FInternalMethodMap['Assert'] := TLapeTree_InternalMethod_Assert;
   FInternalMethodMap['IsScriptMethod'] := TLapeTree_InternalMethod_IsScriptMethod;
   FInternalMethodMap['GetExceptionMessage'] := TLapeTree_InternalMethod_GetExceptionMessage;
+  FInternalMethodMap['GetExceptionLocation'] := TLapeTree_InternalMethod_GetExceptionLocation;
+  FInternalMethodMap['GetExceptionLocationStr'] := TLapeTree_InternalMethod_GetExceptionLocationStr;
+  FInternalMethodMap['GetCallerLocation'] := TLapeTree_InternalMethod_GetCallerLocation;
+  FInternalMethodMap['GetCallerLocationStr'] := TLapeTree_InternalMethod_GetCallerLocationStr;
   FInternalMethodMap['Break'] := TLapeTree_InternalMethod_Break;
   FInternalMethodMap['Continue'] := TLapeTree_InternalMethod_Continue;
   FInternalMethodMap['FallThrough'] := TLapeTree_InternalMethod_FallThrough;

--- a/lpdisassembler.pas
+++ b/lpdisassembler.pas
@@ -79,6 +79,20 @@ var
     Inc(Code, ocSize);
   end;
 
+  procedure DoGetExceptionLocation;
+  begin
+    _WriteLn('GetExceptionLocation');
+    _WriteLn('IncStack %d', [SizeOf(Pointer)]);
+    Inc(Code, ocSize);
+  end;
+
+  procedure DoGetCallerLocation;
+  begin
+    _WriteLn('GetCallerLocation');
+    _WriteLn('IncStack %d', [SizeOf(Pointer)]);
+    Inc(Code, ocSize);
+  end;
+
   procedure DoInitStackLen; {$IFDEF Lape_Inline}inline;{$ENDIF}
   begin
     _WriteLn('InitStackLen %d', [PStackOffset(PtrUInt(Code) + ocSize)^]);

--- a/lpeval.pas
+++ b/lpeval.pas
@@ -22,12 +22,14 @@ type
   TGetEvalRes = function(Op: EOperator; Left, Right: ELapeBaseType): ELapeBaseType;
   TGetEvalProc = function(Op: EOperator; Left, Right: ELapeBaseType): TLapeEvalProc;
 
+procedure _LapeLocationToStr(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+
 procedure _LapeWrite(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 procedure _LapeWriteLn(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 
 procedure _LapeAssigned(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
-procedure _LapeRaise(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 procedure _LapeRaiseString(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+procedure _LapeRaiseStringWithDocPos(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 procedure _LapeAssert(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 procedure _LapeAssertMsg(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 procedure _LapeRangeCheck(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
@@ -545,6 +547,21 @@ uses
 type
   PBoolean = ^Boolean; //Make sure it's not ^Byte
 
+procedure _LapeLocationToStr(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+
+  function LocationToStr(DocPos: TDocPos): String;
+  begin
+    Result := '';
+    if (DocPos.Line > 0) and (DocPos.Col > 0) then
+      Result := 'Line ' + IntToStr(DocPos.Line) + ', Column ' + IntToStr(DocPos.Col);
+    if (DocPos.FileName <> '') then
+      Result := Result + ' in file "' + DocPos.FileName + '"';
+  end;
+
+begin
+  PlpString(Result)^ := LocationToStr(PDocPos(Params^[0]^)^);
+end;
+
 procedure _LapeWrite(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
   Write(PlpString(Params^[0])^);
@@ -560,14 +577,14 @@ begin
   PEvalBool(Result)^ := Assigned(Params^[0]) and Assigned(PPointer(Params^[0])^);
 end;
 
-procedure _LapeRaise(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
-begin
-  raise Exception(Params^[0]^);
-end;
-
 procedure _LapeRaiseString(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
   LapeException(PlpString(Params^[0])^);
+end;
+
+procedure _LapeRaiseStringWithDocPos(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  LapeException(PlpString(Params^[0])^, PDocPos(Params^[1]^)^);
 end;
 
 procedure _LapeAssert(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}

--- a/lpinterpreter_opcodecase.inc
+++ b/lpinterpreter_opcodecase.inc
@@ -11,6 +11,8 @@ case opCode(opCodeTypeP(Code)^) of
   ocNone: Break;
   ocIsInternal: DoCheckInternal();
   ocGetExceptionMessage: DoGetExceptionMessage();
+  ocGetExceptionLocation: DoGetExceptionLocation();
+  ocGetCallerLocation: DoGetCallerLocation();
   ocInitStackLen: DoInitStackLen();
   ocInitVarLen: DoInitVarLen();
   ocInitStack: DoInitStack();

--- a/lpparser.pas
+++ b/lpparser.pas
@@ -27,6 +27,7 @@ type
     tk_NewLine,
 
     //Keywords
+    tk_kw_At,
     tk_kw_Array,
     tk_kw_Begin,
     tk_kw_Case,
@@ -251,7 +252,7 @@ const
   ParserToken_Symbols = [tk_sym_BracketClose..tk_sym_SemiColon];
   ParserToken_Types = [tk_typ_Float..tk_typ_Char];
 
-  Lape_Keywords: array[0..53 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
+  Lape_Keywords: array[0..54 {$IFDEF Lape_PascalLabels}+1{$ENDIF}] of TLapeKeyword = (
       (Keyword: 'AND';           Token: tk_op_AND),
       (Keyword: 'DIV';           Token: tk_op_DIV),
       (Keyword: 'IN';            Token: tk_op_IN),
@@ -263,6 +264,7 @@ const
       (Keyword: 'SHR';           Token: tk_op_SHR),
       (Keyword: 'XOR';           Token: tk_op_XOR),
 
+      (Keyword: 'AT';            Token: tk_kw_At),
       (Keyword: 'ARRAY';         Token: tk_kw_Array),
       (Keyword: 'BEGIN';         Token: tk_kw_Begin),
       (Keyword: 'CASE';          Token: tk_kw_Case),

--- a/tests/Exception_Raise.lap
+++ b/tests/Exception_Raise.lap
@@ -1,0 +1,61 @@
+{$assertions on}
+
+const
+  CURRENT_FILE = {$MACRO CURRENT_FILE};
+
+procedure Foo(AtCaller: Boolean);
+begin
+  if AtCaller then
+    raise 'Foo' at GetCallerLocation()
+  else
+    raise 'Foo';
+end;
+
+procedure Bar(AtCaller: Boolean);
+begin
+  Foo(AtCaller);
+end;
+
+begin
+  try
+    Bar(False);
+  except
+    Assert(GetExceptionMessage() = 'Foo');
+    Assert(GetExceptionLocationStr() = 'Line 11, Column 5 in file "' + CURRENT_FILE + '"');
+  end;
+
+  try
+    Bar(True);
+  except
+    Assert(GetExceptionMessage() = 'Foo');
+    Assert(GetExceptionLocationStr() = 'Line 16, Column 6 in file "' + CURRENT_FILE + '"');
+  end;
+end;
+
+procedure ReRaise(AtCaller: Boolean);
+begin
+  try
+    raise 'ReRaise';
+  except
+    if AtCaller then
+      raise at GetCallerLocation
+    else
+      raise;
+  end;
+end;
+
+begin
+  try
+    ReRaise(False);
+  except
+    Assert(GetExceptionMessage() = 'ReRaise');
+    Assert(GetExceptionLocationStr() = 'Line 38, Column 5 in file "' + CURRENT_FILE + '"');
+  end;
+
+  try
+    ReRaise(True);
+  except
+    Assert(GetExceptionMessage() = 'ReRaise');
+    Assert(GetExceptionLocationStr() = 'Line 56, Column 12 in file "' + CURRENT_FILE + '"');
+  end;
+end;


### PR DESCRIPTION
Lape now supports fancyness like:

```pascal
raise 'Some Exception' at GetCallerLocation();
```

`GetCallerLocation` `GetExceptionLocation` returns pointer to DocPos.

Use `GetCallerLocationStr` `GetExceptionLocationStr` for string.