### PR TITLE
Fix TLapeTree_Operator.Compile locks (locks were never increased and always decreased)

### DIFF
--- a/lptree.pas
+++ b/lptree.pas
@@ -2937,6 +2937,8 @@ begin
   else
     RightVar := NullResVar;
 
+  LeftVar.IncLock();
+  RightVar.IncLock();
   try
     if DoneAssignment then
     begin

--- a/tests/Bugs/OpAssignLocks.lap
+++ b/tests/Bugs/OpAssignLocks.lap
@@ -1,0 +1,35 @@
+type
+  TArrayRecord = record
+    a: TIntegerArray;
+    b,c: String;
+  end;
+
+var
+  i: Integer = 0;
+
+procedure Test1(a: TArrayRecord);
+begin
+end;
+
+procedure Test2(const a: TArrayRecord);
+begin
+end;
+
+procedure Test3(constref a: TArrayRecord);
+begin
+end;
+
+function GetArray: TIntegerArray;
+begin
+  Result := [i+=1, i+=1, i+=1];
+end;
+
+var
+  Arr: TIntegerArray;
+begin
+  Arr := GetArray();
+  GetArray();
+  Test1([]);
+  Test2([]);
+  Test3([]);
+end.


### PR DESCRIPTION
Solution is just to just increase the locks & added a test that would crash badly.