### PR TITLE
Fix in operator with open arrays

### DIFF
--- a/lpinternalmethods.pas
+++ b/lpinternalmethods.pas
@@ -59,11 +59,6 @@ type
     function Compile(var Offset: Integer): TResVar; override;
   end;
 
-  TLapeTree_InternalMethod_Operator = class(TLapeTree_InternalMethod)
-  public
-    constructor Create(AOperator:EOperator; ACompiler: TLapeCompilerBase; ADocPos: PDocPos = nil); reintroduce;
-  end;
-
   TLapeTree_InternalMethod_Exit = class(TLapeTree_InternalMethod)
   public
     function Compile(var Offset: Integer): TResVar; override;
@@ -942,11 +937,6 @@ begin
     LapeException(lpeCannotContinue, DocPos)
   else
       FoundNode.addContinueStatement(JumpSafe, Offset, @_DocPos);
-end;
-
-constructor TLapeTree_InternalMethod_Operator.Create(AOperator:EOperator; ACompiler: TLapeCompilerBase; ADocPos: PDocPos = nil);
-begin
-  inherited Create('!op_'+op_name[AOperator], ACompiler, ADocPos);
 end;
 
 function TLapeTree_InternalMethod_Exit.Compile(var Offset: Integer): TResVar;

--- a/lpinternalmethods_algorithm.pas
+++ b/lpinternalmethods_algorithm.pas
@@ -503,7 +503,6 @@ end;
 
 function TLapeTree_InternalMethod_ArrayMode.Compile(var Offset: Integer): TResVar;
 var
-  ArrayVar, SortedArrayVar, LengthVar: TResVar;
   ArrayElementType: TLapeType;
 begin
   Result := NullResVar;
@@ -666,7 +665,6 @@ end;
 
 function TLapeTree_InternalMethod_ArrayMean.Compile(var Offset: Integer): TResVar;
 var
-  ArrayVar, CounterVar: TResVar;
   ArrayElementType: TLapeType;
 begin
   Result := NullResVar;

--- a/lpmessages.pas
+++ b/lpmessages.pas
@@ -86,6 +86,9 @@ const
   lpeInvalidCast = 'Invalid cast';
   lpeInvalidCaseStatement = 'Invalid case statement';
   lpeInvalidCondition = 'Invalid condition';
+  lpeInvalidConstSet = 'Invalid constant set';
+  lpeInvalidConstByteSet = 'Invalid constant (Byte) set';
+  lpeInvalidConstCharSet = 'Invalid constant (Char) set';
   lpeInvalidCompareMethod = 'Invalid compare method';
   lpeInvalidEvaluation = 'Invalid evaluation';
   lpeInvalidForward = 'Forwarded declaration "%s" not resolved';
@@ -100,6 +103,7 @@ const
   lpeInvalidUnionType = 'Invalid union type';
   lpeInvalidValueForType = 'Invalid value for type "%s"';
   lpeInvalidWithReference = 'Invalid with-reference';
+  lpeInvalidSet = 'Invalid set';
   lpeLostClosingParenthesis = 'Found closing parenthesis without matching opening parenthesis';
   lpeLostConditional = 'Found conditional without matching opening statement';
   lpeMethodOfObjectExpected = 'Expected method of object';

--- a/lptree.pas
+++ b/lptree.pas
@@ -2772,7 +2772,7 @@ begin
   Result := inherited resType();
 
   // check for op overload
-  if (FResType = nil) and (FOperatorType in OverloadableOperators) and HasOperatorOverload(FCompiler, FOperatorType, LeftType, RightType, Result) then
+  if (FResType = nil) and HasOperatorOverload(FCompiler, FOperatorType, LeftType, RightType, Result) then
   begin
     FResType := Result;
     FOverloadOp := True;
@@ -2920,7 +2920,7 @@ var
   function DoOperatorOverload(): TResVar;
   begin
     Dest := NullResVar;
-    with TLapeTree_InternalMethod_Operator.Create(FOperatorType, FCompiler, @_DocPos) do
+    with TLapeTree_Invoke.Create('!op_'+op_name[FOperatorType], FCompiler, @_DocPos) do
     try
       addParam(Left);
       addParam(Right);

--- a/lpvartypes.pas
+++ b/lpvartypes.pas
@@ -4406,7 +4406,6 @@ begin
       BaseType := DetermineIntType(Value)
     else
       BaseType := DetermineIntType(Value, BaseType, False);
-
     Assert(BaseType in LapeIntegerTypes);
   end;
 

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -420,7 +420,6 @@ var
   Idx: SizeInt;
   Lo, Hi: TLapeGlobalVar;
   Check, Len: TLapeTree_Invoke;
-  TempVar, DestVar, ArrayPtrVar: TResVar;
 begin
   if (not AIndex.HasType()) then
     LapeException(lpeInvalidEvaluation)

--- a/tests/Operator_In.lap
+++ b/tests/Operator_In.lap
@@ -1,0 +1,25 @@
+{$assertions on}
+
+type
+  EEnum = (e1,e2,e3,e4,e5,e6,e7,e9);
+
+var
+  e: EEnum;
+  i: Int32;
+  c: Char;
+begin
+  e := e1;
+  Assert(not (e in [e3,e2]));
+  Assert(e in [e3,e2,e1]);
+  e := e5;
+  Assert(not (e in [e1,e2,e6..e9]));
+  Assert(e in [e1,e2,e5..e9]);
+
+  i := 100;
+  Assert(not (i in [1..99]));
+  Assert(i in [1..200]);
+
+  c := 'z';
+  Assert(not (c in ['a', 'd'..'y', '0']));
+  Assert(c in ['a', 'd'..'y', 'z']);
+end;

--- a/tests/Operator_InOvl.lap
+++ b/tests/Operator_InOvl.lap
@@ -1,0 +1,32 @@
+{$assertions on}
+
+var success: Boolean;
+
+operator in(l: Int32; r: array of Int64): Boolean;
+begin
+  success := True;
+end;
+
+operator in(l: Int32; r: array of Int32): Boolean;
+begin
+  Success := True;
+end;
+
+operator in(l: Char; r: String): Boolean;
+begin
+  success := True;
+end;
+
+var
+  i: Int32;
+  b: Boolean;
+begin
+  success := False;
+  i := 100;
+  b := i in [0, 1..50]; // should call an op overload
+  assert(success);
+
+  success := False;
+  b := 'z' in 'abc';
+  Assert(success);
+end;


### PR DESCRIPTION
For example `1 in [1,3,10..100]` would not use set methods but use a multi-if statement. This goes for character sets and enum sets.

The multi if statement has been removed too as it had terrible compile time overhead.