### PR TITLE
Add object type

### DIFF
--- a/lpeval.pas
+++ b/lpeval.pas
@@ -282,6 +282,66 @@ var
     '  end;'                                                                             + LineEnding +
     'end;';
 
+  _LapeObjectSetLength: lpString =
+    'procedure _ObjectSetLength(var p: Pointer; NewLen: SizeInt;'                        + LineEnding +
+    '  ObjectDispose: private procedure(constref p: Pointer));'                          + LineEnding +
+    'const'                                                                              + LineEnding +
+    '  HeaderSize = SizeOf(PtrInt) + SizeOf(SizeInt);'                                   + LineEnding +
+    'var'                                                                                + LineEnding +
+    '  i, OldLen, NewSize: SizeInt;'                                                     + LineEnding +
+    '  NewP: Pointer;'                                                                   + LineEnding +
+    '  DoFree: EvalBool;'                                                                + LineEnding +
+    'begin'                                                                              + LineEnding +
+    '  NewSize := NewLen;'                                                               + LineEnding +
+    '  DoFree := NewSize <= 0;'                                                          + LineEnding +
+    '  Inc(NewSize, HeaderSize);'                                                        + LineEnding +
+    ''                                                                                   + LineEnding +
+    '  if (p = nil) then'                                                                + LineEnding +
+    '  begin'                                                                            + LineEnding +
+    '    if DoFree then'                                                                 + LineEnding +
+    '      Exit;'                                                                        + LineEnding +
+    '    p := AllocMem(NewSize);'                                                        + LineEnding +
+    ''                                                                                   + LineEnding +
+    '    PtrInt(p^) := 1;'                                                               + LineEnding +
+    '    Inc(p, SizeOf(PtrInt));'                                                        + LineEnding +
+    '    SizeInt(p^) := NewLen' {$IFDEF FPC}+'-1'{$ENDIF}+';'                            + LineEnding +
+    '    Inc(p, SizeOf(SizeInt));'                                                       + LineEnding +
+    '    Exit;'                                                                          + LineEnding +
+    '  end;'                                                                             + LineEnding +
+    ''                                                                                   + LineEnding +
+    '  Dec(p, SizeOf(SizeInt));'                                                         + LineEnding +
+    '  OldLen := p^' {$IFDEF FPC}+'+1'{$ENDIF}+';'                                       + LineEnding +
+    '  Dec(p, SizeOf(PtrInt));'                                                          + LineEnding +
+    ''                                                                                   + LineEnding +
+    '  if (PtrInt(p^) <= 1) then'                                                        + LineEnding +
+    '  begin'                                                                            + LineEnding +
+    '    if DoFree then'                                                                 + LineEnding +
+    '    begin'                                                                          + LineEnding +
+    '      Inc(p, HeaderSize);'                                                          + LineEnding +
+    '      ObjectDispose(p);'                                                            + LineEnding +
+    '      Dec(p, HeaderSize);'                                                          + LineEnding +
+    ''                                                                                   + LineEnding +
+    '      FreeMem(p);'                                                                  + LineEnding +
+    '      p := nil;'                                                                    + LineEnding +
+    '      Exit;'                                                                        + LineEnding +
+    '    end;'                                                                           + LineEnding +
+    '    ReallocMem(p, NewSize);'                                                        + LineEnding +
+    '    PtrInt(p^) := 1;'                                                               + LineEnding +
+    '    Inc(p, SizeOf(PtrInt));'                                                        + LineEnding +
+    '    SizeInt(p^) := NewLen' {$IFDEF FPC}+'-1'{$ENDIF}+';'                            + LineEnding +
+    '    Inc(p, SizeOf(SizeInt));'                                                       + LineEnding +
+    ''                                                                                   + LineEnding +
+    '    if (NewLen > OldLen) then'                                                      + LineEnding +
+    '      FillMem(p[OldLen]^, (NewLen - OldLen));'                                      + LineEnding +
+    '  end'                                                                              + LineEnding +
+    '  else'                                                                             + LineEnding +
+    '  begin'                                                                            + LineEnding +
+    '    Dec(PtrInt(p^));'                                                               + LineEnding +
+    '    p := nil;'                                                                      + LineEnding +
+    '    _ObjectSetLength(p, NewLen, ObjectDispose);'                                    + LineEnding +
+    '  end;'                                                                             + LineEnding +
+    'end;';
+
   _LapeCopy: lpString =
     'procedure _ArrayCopy(p: ConstPointer;'                                              + LineEnding +
     '  Start: SizeInt = 0; Count: SizeInt = High(SizeInt);'                              + LineEnding +

--- a/lptree.pas
+++ b/lptree.pas
@@ -225,6 +225,7 @@ type
     ESpecialParam = (
       spNo,    // normal parameters
       spForce, // force the next expression to be the parameter even without parentheses
+      spTypeThenParams,
       spType   // type parameter in <> like generics
     );
   protected

--- a/lpvartypes_array.pas
+++ b/lpvartypes_array.pas
@@ -524,6 +524,8 @@ begin
     Result := FPType
   else if (op = op_Assign) and (BaseType = ltDynArray) and HasType() and (ARight <> nil) and (ARight is ClassType) and FPType.Equals(TLapeType_DynArray(ARight).FPType) then
     Result := Self
+  else if (op = op_Assign) and (BaseType = ltDynArray) and HasType() and (ARight is TLapeType_NilPointer) then
+    Result := Self
   else if (op = op_Plus) and (BaseType = ltDynArray) and HasType() and FPType.CompatibleWith(ARight) then
     Result := Self
   else if (op = op_Plus) and (BaseType = ltDynArray) and HasType() and (ARight <> nil) and (ARight is ClassType) and FPType.Equals(TLapeType_DynArray(ARight).FPType) then
@@ -749,6 +751,18 @@ begin
       try
         Left := TLapeTree_ResVar.Create(IndexVar.IncLock(), FCompiler, Pos);
         Right := TLapeTree_ResVar.Create(ARight.IncLock(), Left);
+        Compile(Offset);
+      finally
+        Free();
+      end;
+    end
+    else if (ARight.VarType is TLapeType_NilPointer) then
+    begin
+      with TLapeTree_InternalMethod_SetLength.Create(FCompiler, Pos) do
+      try
+        addParam(TLapeTree_ResVar.Create(ALeft.IncLock(), FCompiler, Pos));
+        addParam(TLapeTree_GlobalVar.Create(FCompiler.getConstant(0), FCompiler, Pos));
+
         Compile(Offset);
       finally
         Free();

--- a/lpvartypes_object.pas
+++ b/lpvartypes_object.pas
@@ -1,0 +1,219 @@
+{
+  Author: Niels A.D
+  Project: Lape (https://github.com/nielsAD/lape)
+  License: GNU Lesser GPL (http://www.gnu.org/licenses/lgpl.html)
+}
+unit lpvartypes_object;
+
+{$I lape.inc}
+
+interface
+
+uses
+  Classes, SysUtils,
+  lptypes, lpvartypes, lpvartypes_array;
+
+type
+  TObjectField = record
+    Offset: Word;
+    FieldType: TLapeType;
+  end;
+  TObjectFieldMap = {$IFDEF FPC}specialize{$ENDIF} TLapeStringMap<TObjectField>;
+
+  TLapeType_Object = class(TLapeType_DynArray)
+  protected
+    FFieldMap: TObjectFieldMap;
+    FTotalFieldSize: Integer;
+
+    function getAsString: lpString; override;
+  public
+    FreeFieldMap: Boolean;
+
+    constructor Create(ACompiler: TLapeCompilerBase; AFieldMap: TObjectFieldMap = nil; AName: lpString = ''; ADocPos: PDocPos = nil); reintroduce;
+    function CreateCopy(DeepCopy: Boolean = False): TLapeType; override;
+    destructor Destroy; override;
+
+    procedure ClearCache; override;
+    function VarToStringBody(ToStr: TLapeType_OverloadedMethod = nil): lpString; override;
+
+    procedure addField(FieldType: TLapeType; AName: lpString); virtual;
+    procedure addConstField(FieldType: TLapeType; FieldValue: TLapeGlobalVar; AName: lpString); virtual;
+
+    function HasChild(AName: lpString): Boolean; overload; override;
+    function EvalRes(Op: EOperator; Right: TLapeGlobalVar; Flags: ELapeEvalFlags = []): TLapeType; override;
+    function Eval(Op: EOperator; var Dest: TResVar; Left, Right: TResVar; Flags: ELapeEvalFlags; var Offset: Integer; Pos: PDocPos = nil): TResVar; override;
+    function EvalConst(Op: EOperator; ALeft, ARight: TLapeGlobalVar; Flags: ELapeEvalFlags): TLapeGlobalVar; override;
+
+    procedure addArrayHelpers; override;
+
+    property FieldMap: TObjectFieldMap read FFieldMap;
+    property TotalFieldSize: Integer read FTotalFieldSize;
+  end;
+
+implementation
+
+uses
+  lpmessages;
+
+function TLapeType_Object.getAsString: lpString;
+var
+  i: Integer;
+begin
+  if (FAsString = '') then
+  begin
+    FAsString := 'object ';
+    for i := 0 to FFieldMap.Count - 1 do
+      FAsString := FAsString + '[' + lpString(IntToStr(FFieldMap.ItemsI[i].Offset)) + ']' + FFieldMap.Key[i] + ': ' + FFieldMap.ItemsI[i].FieldType.AsString + '; ';
+    FAsString := FAsString + 'end';
+  end;
+  Result := inherited;
+end;
+
+constructor TLapeType_Object.Create(ACompiler: TLapeCompilerBase; AFieldMap: TObjectFieldMap; AName: lpString; ADocPos: PDocPos);
+const
+  InvalidRec: TObjectField = (Offset: Word(-1); FieldType: nil);
+begin
+  inherited Create(ACompiler.getBaseType(ltUInt8), ACompiler, AName, ADocPos);
+
+  FreeFieldMap := (AFieldMap = nil);
+  if (AFieldMap = nil) then
+    AFieldMap := TObjectFieldMap.Create(InvalidRec, dupError, False);
+  FFieldMap := AFieldMap;
+end;
+
+destructor TLapeType_Object.Destroy;
+begin
+  if FreeFieldMap then
+    FreeAndNil(FFieldMap);
+
+  inherited Destroy();
+end;
+
+procedure TLapeType_Object.ClearCache;
+begin
+  FAsString := '';
+end;
+
+function TLapeType_Object.VarToStringBody(ToStr: TLapeType_OverloadedMethod): lpString;
+var
+  i: Integer;
+begin
+  Result := 'begin Result := '#39'{'#39;
+  for i := 0 to FFieldMap.Count - 1 do
+    with FFieldMap.ItemsI[i] do
+    begin
+      if (i > 0) then
+        Result := Result + ' + ' + #39', '#39;
+      if (ToStr <> nil) and (ToStr.getMethod(getTypeArray([FieldType])) <> nil) then
+        Result := Result + ' + '#39 + FFieldMap.Key[i] + ' = '#39' + System.ToString(Param0.' + FFieldMap.Key[i] + ')';
+    end;
+  Result := Result + ' + '#39'}'#39'; end;';
+end;
+
+function TLapeType_Object.CreateCopy(DeepCopy: Boolean): TLapeType;
+type
+  TLapeClassType = class of TLapeType_Object;
+begin
+  if DeepCopy then
+  begin
+    Result := TLapeClassType(Self.ClassType).Create(FCompiler, nil, Name);
+    TLapeType_Object(Result).FFieldMap.ImportFromArrays(FFieldMap.ExportToArrays());
+  end
+  else
+    Result := TLapeClassType(Self.ClassType).Create(FCompiler, FFieldMap, Name);
+
+  with TLapeType_Object(Result) do
+  begin
+    inheritManagedDecls(Self, not DeepCopy);
+    TypeID := Self.TypeID;
+    FTotalFieldSize := Self.FTotalFieldSize;
+    CopyHints(Self);
+  end;
+end;
+
+procedure TLapeType_Object.addField(FieldType: TLapeType; AName: lpString);
+var
+  Field: TObjectField;
+begin
+  Field.Offset := FTotalFieldSize;
+  Field.FieldType := FieldType;
+
+  FFieldMap[AName] := Field;
+
+  Inc(FTotalFieldSize, FieldType.Size);
+end;
+
+procedure TLapeType_Object.addConstField(FieldType: TLapeType; FieldValue: TLapeGlobalVar; AName: lpString);
+var
+  Field: TLapeGlobalVar;
+begin
+  Assert(FCompiler <> nil);
+
+  Field := TLapeGlobalVar.Create(FieldType);
+  Field.Name := AName;
+  if (FieldValue <> nil) then
+    FieldType.EvalConst(op_Assign, Field, FieldValue, [lefAssigning]);
+  Field.isConstant := True;
+
+  addSubDeclaration(Field);
+end;
+
+function TLapeType_Object.HasChild(AName: lpString): Boolean;
+begin
+  Result := FFieldMap.ExistsKey(AName) or HasSubDeclaration(AName, bTrue);
+end;
+
+function TLapeType_Object.EvalRes(Op: EOperator; Right: TLapeGlobalVar; Flags: ELapeEvalFlags): TLapeType;
+begin
+  if (Op = op_Dot) and ValidFieldName(Right) and FFieldMap.ExistsKey(PlpString(Right.Ptr)^) then
+    Result := FFieldMap[PlpString(Right.Ptr)^].FieldType
+  else
+    Result := inherited;
+end;
+
+function TLapeType_Object.Eval(Op: EOperator; var Dest: TResVar; Left, Right: TResVar; Flags: ELapeEvalFlags; var Offset: Integer; Pos: PDocPos): TResVar;
+var
+  Field: TObjectField;
+begin
+  if (Op = op_Dot) and ValidFieldName(Right) and FFieldMap.ExistsKey(PlpString(Right.VarPos.GlobalVar.Ptr)^) then
+  begin
+    Assert(FCompiler <> nil);
+    Assert(Left.VarType = Self);
+
+    Result := NullResVar;
+    Dest := NullResVar;
+    Field := FFieldMap[PlpString(Right.VarPos.GlobalVar.Ptr)^];
+
+    Left.VarType := FCompiler.getBaseType(ltPointer);
+
+    Result := Left.VarType.Eval(op_Plus, Dest, Left, _ResVar.New(FCompiler.getConstant(Field.Offset)), Flags, Offset, Pos);
+    Result := Result.VarType.Eval(op_Deref, Dest, Result, NullResVar, [], Offset, Pos);
+    Result.CopyFlags(Left);
+    Result.VarType := Field.FieldType;
+
+    Left.VarType := Self;
+  end else
+    Result := inherited;
+end;
+
+function TLapeType_Object.EvalConst(Op: EOperator; ALeft, ARight: TLapeGlobalVar; Flags: ELapeEvalFlags): TLapeGlobalVar;
+begin
+  if (Op = op_Dot) and (ALeft <> nil) and ValidFieldName(ARight) and FFieldMap.ExistsKey(PlpString(ARight.Ptr)^) then
+  begin
+    with FFieldMap[PlpString(ARight.Ptr)^] do
+    begin
+      Result := FieldType.NewGlobalVarP(Pointer(PtrUInt(ALeft.Ptr) + Offset));
+      Result.CopyFlags(ALeft);
+    end
+  end else
+    Result := inherited;
+end;
+
+procedure TLapeType_Object.addArrayHelpers;
+begin
+  { nothing }
+end;
+
+
+end.
+

--- a/lpvartypes_record.pas
+++ b/lpvartypes_record.pas
@@ -38,7 +38,7 @@ type
 
     procedure ClearCache; override;
     procedure addField(FieldType: TLapeType; AName: lpString; AAlignment: UInt16 = 1); virtual;
-    procedure addClassField(FieldType: TLapeType; FieldValue: TLapeGlobalVar; AName: lpString; IsConst: Boolean); virtual;
+    procedure addConstField(FieldType: TLapeType; FieldValue: TLapeGlobalVar; AName: lpString); virtual;
 
     function VarToStringBody(ToStr: TLapeType_OverloadedMethod = nil): lpString; override;
     function VarToString(AVar: Pointer): lpString; override;
@@ -196,7 +196,7 @@ begin
   ClearCache();
 end;
 
-procedure TLapeType_Record.addClassField(FieldType: TLapeType; FieldValue: TLapeGlobalVar; AName: lpString; IsConst: Boolean);
+procedure TLapeType_Record.addConstField(FieldType: TLapeType; FieldValue: TLapeGlobalVar; AName: lpString);
 var
   Field: TLapeGlobalVar;
 begin
@@ -205,9 +205,8 @@ begin
   Field := TLapeGlobalVar.Create(FieldType);
   Field.Name := AName;
   if (FieldValue <> nil) then
-    FieldType.EvalConst(op_Assign, Field, FieldValue, []);
-
-  Field.isConstant := IsConst;
+    FieldType.EvalConst(op_Assign, Field, FieldValue, [lefAssigning]);
+  Field.isConstant := True;
 
   addSubDeclaration(Field);
 end;

--- a/tests/Bitmap.lap
+++ b/tests/Bitmap.lap
@@ -1,0 +1,98 @@
+{$assertions on}
+
+var
+  creates, destroys: Integer;
+  allocations: array of Pointer;
+
+function MyAllocMem(i: SizeInt): Pointer;
+begin
+  Result := AllocMem(i);
+  allocations += Result;
+  inc(creates);
+end;
+
+procedure MyFreeMem(p: Pointer);
+begin
+  FreeMem(p);
+  allocations.remove(p);
+  inc(destroys);
+end;
+
+type
+  TBitmap = object
+    width, height: Integer;
+    data: ^Byte;
+  end;
+
+procedure TBitmap.Construct(width, height: Integer);
+begin
+  Self.width := width;
+  Self.height := height;
+  Self.data := MyAllocMem(width*height*4);
+end;
+
+procedure TBitmap.Destroy;
+begin
+  MyFreeMem(self.data);
+end;
+
+procedure TBitmap.Fill(color: Integer);
+var
+  i: Integer;
+  ptr: ^Int32;
+begin
+  ptr := Pointer(self.data);
+  for i:=0 to self.width*self.height-1 do
+  begin
+    ptr^ := color;
+    inc(ptr);
+  end;
+end;
+
+// Test that object is cleaning up as expected
+procedure Test;
+
+  procedure TestParams(const a: TBitmap; constref b: TBitmap; var c: TBitmap; out d: TBitmap; e: TBitmap);
+  begin
+    a.fill(1);
+    b.fill(2);
+    c.fill(3);
+    c := new TBitmap(c.width+1, c.height+1);
+    d.fill(4);
+    d := new TBitmap(d.width+1, d.height+1);
+    e.fill(5);
+  end;
+
+var bmp: TBitmap;
+var bmps: array of TBitmap;
+var i: Integer;
+begin
+  bmp := new TBitmap(20, 20);
+  Assert(creates = 1);
+  Assert(destroys = 0);
+
+  for i:=1 to 20 do
+  begin
+    bmp := new TBitmap(bmp.width+1, bmp.height+1);
+    if (i mod 2 = 0) then
+      bmps += bmp;
+  end;
+  Assert(creates = 21);
+  Assert(destroys = 10);
+
+  Assert(creates = 21);
+  TestParams(bmps[7], bmps[6], bmps[5], bmps[4], bmps[3]);
+  Assert(creates = 23);
+
+  Assert(destroys = 12);
+  for i := 2 to 5 do
+    bmps[i] := [];
+  Assert(destroys = 16);
+end;
+
+begin
+  Test();
+  Assert(Length(allocations) = 0);
+  Assert(creates = 23);
+  Assert(destroys = 23);
+end.

--- a/tests/Bugs/DynArrNil.lap
+++ b/tests/Bugs/DynArrNil.lap
@@ -1,0 +1,29 @@
+{$assertions on}
+
+var
+  a: array of Int32;
+  b: array of array of Int32;
+
+begin
+  a := [1,2,3];
+  a := nil;
+  Assert(Length(a) = 0);
+
+  a += 10;
+  a := nil;
+  Assert(Length(a) = 0);
+
+  SetLength(a,10);
+  a := nil;
+  Assert(Length(a) = 0);
+
+  b := [[1,2,3],[4,5,6]];
+  b[0] := nil;
+  Assert(Length(b) = 2);
+  Assert(Length(b[0]) = 0);
+  Assert(Length(b[1]) = 3);
+  b[1] := nil;
+  Assert(Length(b[1]) = 0);
+  b := nil;
+  Assert(Length(b) = 0);
+end;

--- a/tests/Object.lap
+++ b/tests/Object.lap
@@ -1,0 +1,150 @@
+{$assertions on}
+
+var
+  creates, destroys: Int32;
+  tracking: array of Int32;
+
+type
+  TMyObject = object
+    i: Int32;
+    s: String;
+  end;
+
+  TMyComplexObject = object
+    i: Int32;
+    s: String;
+    a: TMyObject;
+    b: array of Int32;
+    c: array of TMyObject;
+  end;
+
+procedure TMyComplexObject.Construct;
+var
+  i: Int32;
+  tmp: array[0..Pred((SizeOf(Pointer)*3) + SizeOf(String) + SizeOf(Int32))] of UInt8;
+begin
+  Assert(Self <> nil);
+  Assert(Length(Self) = Length(tmp));
+  Assert(CompareMem(tmp[0], Self[0], Length(Self)));
+
+  self.i := Inc(creates);
+  self.s := 'Number: ' + IntToStr(self.i);
+
+  SetLength(self.b, creates);
+  SetLength(self.c, creates);
+  for i := 0 to creates-1 do
+  begin
+    self.b[i] := i;
+    self.c[i] := new TMyObject;
+  end;
+
+  tracking += self.i;
+end;
+
+procedure TMyComplexObject.Destroy;
+var
+  i: Integer;
+begin
+  Assert(self.s = 'Number: ' + IntToStr(self.i));
+  for i := 0 to High(tracking) do
+    if (tracking[i] = self.i) then
+      tracking[i] := -1;
+
+  Inc(destroys);
+end;
+
+procedure TMyObject.Construct;
+var
+  tmp: array[0..Pred(SizeOf(Int32) + SizeOf(Pointer))] of UInt8;
+begin
+  Assert(Self <> nil);
+  Assert(Length(Self) = Length(tmp));
+  Assert(CompareMem(tmp[0], Self[0], Length(Self)));
+
+  self.i := Inc(creates);
+  self.s := 'Number: ' + IntToStr(self.i);
+
+  tracking += self.i;
+end;
+
+procedure TMyObject.Destroy;
+var
+  i: Int32;
+begin
+  Assert(self.s = 'Number: ' + IntToStr(self.i));
+  for i := 0 to High(tracking) do
+    if (tracking[i] = self.i) then
+      tracking[i] := -1;
+
+  Inc(destroys);
+end;
+
+procedure test;
+var
+  obj: TMyObject;
+  obj2: TMyObject;
+begin
+  obj := new TMyObject;
+  obj2 := obj;
+  obj := new TMyObject;
+  for 1 to 3 do
+    obj := new TMyObject;
+  obj := new TMyObject;
+end;
+
+procedure testRef;
+var
+  obj: TMyObject;
+  a,b,c: TMyObject;
+  p: Pointer;
+begin
+  obj := new TMyObject;
+  a := obj;
+  b := obj;
+  c := obj;
+end;
+
+procedure testLoop;
+var
+  obj: TMyObject;
+  i: Integer;
+begin
+  for i:=1 to 5 do
+    obj := new TMyObject;
+end;
+
+procedure testArray;
+var
+  a: array of TMyObject;
+begin
+  SetLength(a,5);
+  a[0] := new TMyObject;
+  a[3] := new TMyObject;
+end;
+
+procedure testComplex;
+var
+  a: TMyComplexObject;
+  b: array of TMyComplexObject;
+begin
+  a := new TMyComplexObject;
+  SetLength(a.c,3);
+  a.c[2] := new TMyObject;
+
+  b += new TMyComplexObject;
+  b += new TMyComplexObject;
+end;
+
+var i: Int32;
+begin
+  test();
+  testRef();
+  testLoop();
+  testComplex();
+  testArray();
+
+  Assert(creates = destroys);
+  Assert(creates = Length(tracking));
+  for i := 0 to High(tracking) do
+    Assert(tracking[i] = -1);
+end.


### PR DESCRIPTION
The object type is basically a record passed around by reference with a construct/destroy method.
Internally a object is a dynamic array of bytes so all ref/management is equal to how dyn arrays operate.

Objects are declared just like records, and are always packed.
```pascal
type
  TMyObject = object
    a: Integer;
    b: String;
  end;
```
Construct/Destroy methods
```pascal
procedure TMyObject.Construct;
begin
end;

procedure TMyObject.Construct(a,b,c: Integer); overload;
begin
end;

procedure TMyObject.Destroy;
begin
end;
```

The new keyword is used to construct a object like so:
```pascal
var o: TMyObject;
begin
  o := new TMyObject();
  o := new TMyObject(1,2,3);
end.
```